### PR TITLE
Delete link to osiam.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ like Docker? No problem! Take the
 ## Documentation
 
 Learn how to install and configure OSIAM for production in the
-[documentation](docs/README.md). For additional information visit our official
-website https://www.osiam.org.
+[documentation](docs/README.md).
 
 ## Components
 


### PR DESCRIPTION
Fixes #27

The link is obsolete because there is currently no website at osiam.org
and it redirects to this very github project.
