### PR TITLE
Migrate to BCrypt hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changes
 
-- Require a Java runtime enviroment of at least version 8
+- Require a Java runtime environment of at least version 8
 
 - Remove usage of old, method-based OAuth scopes
 - Remove support for old, method-based OAuth scopes
@@ -35,6 +35,10 @@
   database, an initial admin user will be created. The details of the client and
   user will be logged. This removes the creation of initial data during the
   database setup.
+- Migrate to BCrypt hashes
+  When users login, their passwords will be updated to the new BCrypt hashes.
+  Until the Release 4.0 the old sha password hashes will be supported.
+  After OSIAM 4.0 was released the old password hashes are not usable anymore.
 
 ## Old Versions
 
@@ -42,4 +46,3 @@ You can find the changelog of older versions < 3.x here:
 
 - [auth-server](https://github.com/osiam/auth-server/blob/master/CHANGELOG.md)
 - [resource-server](https://github.com/osiam/resource-server/blob/master/CHANGELOG.md)
-

--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.Collections;
 import java.util.Map;
@@ -87,9 +88,14 @@ public class Osiam extends SpringBootServletInitializer {
     }
 
     @Bean
-    public ShaPasswordEncoder passwordEncoder() {
-        ShaPasswordEncoder passwordEncoder = new ShaPasswordEncoder(512);
-        passwordEncoder.setIterations(1000);
-        return passwordEncoder;
+    public ShaPasswordEncoder shaPasswordEncoder() {
+        ShaPasswordEncoder shaPasswordEncoder = new ShaPasswordEncoder(512);
+        shaPasswordEncoder.setIterations(1000);
+        return shaPasswordEncoder;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder(13);
     }
 }

--- a/src/main/java/org/osiam/configuration/WebApplicationSecurity.java
+++ b/src/main/java/org/osiam/configuration/WebApplicationSecurity.java
@@ -32,7 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;

--- a/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMUserProvisioning.java
@@ -37,7 +37,7 @@ import org.osiam.storage.query.QueryFilterParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,17 +55,17 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
 
     private final UserConverter userConverter;
     private final UserDao userDao;
-    private final PasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final UserUpdater userUpdater;
 
     @Autowired
     public SCIMUserProvisioning(UserConverter userConverter,
                                 UserDao userDao,
-                                PasswordEncoder passwordEncoder,
+                                BCryptPasswordEncoder bCryptPasswordEncoder,
                                 UserUpdater userUpdater) {
         this.userConverter = userConverter;
         this.userDao = userDao;
-        this.passwordEncoder = passwordEncoder;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.userUpdater = userUpdater;
     }
 
@@ -120,7 +120,7 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
         UserEntity userEntity = userConverter.fromScim(user);
         userEntity.setId(UUID.randomUUID());
 
-        String hashedPassword = passwordEncoder.encodePassword(user.getPassword(), userEntity.getId());
+        String hashedPassword = bCryptPasswordEncoder.encode(user.getPassword());
         userEntity.setPassword(hashedPassword);
 
         userDao.create(userEntity);
@@ -150,7 +150,7 @@ public class SCIMUserProvisioning implements SCIMProvisioning<User> {
         userEntity.setId(existingEntity.getId());
 
         if (user.getPassword() != null && !user.getPassword().isEmpty()) {
-            String hashedPassword = passwordEncoder.encodePassword(user.getPassword(), userEntity.getId());
+            String hashedPassword = bCryptPasswordEncoder.encode(user.getPassword());
             userEntity.setPassword(hashedPassword);
         } else {
             userEntity.setPassword(existingEntity.getPassword());

--- a/src/main/java/org/osiam/resources/provisioning/update/UserUpdater.java
+++ b/src/main/java/org/osiam/resources/provisioning/update/UserUpdater.java
@@ -30,7 +30,7 @@ import org.osiam.resources.scim.User;
 import org.osiam.storage.dao.UserDao;
 import org.osiam.storage.entities.UserEntity;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
@@ -53,7 +53,7 @@ public class UserUpdater {
     private final RoleUpdater roleUpdater;
     private final X509CertificateUpdater x509CertificateUpdater;
     private final AddressUpdater addressUpdater;
-    private final PasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final ExtensionUpdater extensionUpdater;
 
     @Autowired
@@ -68,7 +68,7 @@ public class UserUpdater {
                        RoleUpdater roleUpdater,
                        X509CertificateUpdater x509CertificateUpdater,
                        AddressUpdater addressUpdater,
-                       PasswordEncoder passwordEncoder,
+                       BCryptPasswordEncoder bCryptPasswordEncoder,
                        ExtensionUpdater extensionUpdater) {
         this.userDao = userDao;
         this.resourceUpdater = resourceUpdater;
@@ -81,7 +81,7 @@ public class UserUpdater {
         this.roleUpdater = roleUpdater;
         this.x509CertificateUpdater = x509CertificateUpdater;
         this.addressUpdater = addressUpdater;
-        this.passwordEncoder = passwordEncoder;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.extensionUpdater = extensionUpdater;
     }
 
@@ -234,7 +234,7 @@ public class UserUpdater {
         }
 
         if (!Strings.isNullOrEmpty(user.getPassword())) {
-            String hashedPassword = passwordEncoder.encodePassword(user.getPassword(), userEntity.getId());
+            String hashedPassword = bCryptPasswordEncoder.encode(user.getPassword());
             userEntity.setPassword(hashedPassword);
         }
     }

--- a/src/test/groovy/org/osiam/auth/login/internal/InternalAuthenticationProviderSpec.groovy
+++ b/src/test/groovy/org/osiam/auth/login/internal/InternalAuthenticationProviderSpec.groovy
@@ -23,15 +23,96 @@
  */
 package org.osiam.auth.login.internal
 
+import org.osiam.resources.provisioning.SCIMUserProvisioning
+import org.osiam.resources.scim.User
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.encoding.ShaPasswordEncoder
+import org.springframework.security.core.Authentication
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import spock.lang.Shared
 import spock.lang.Specification
 
 class InternalAuthenticationProviderSpec extends Specification {
 
-    def 'the internal provider only supports InternalAuthentication class'() {
-        given:
-        InternalAuthenticationProvider provider = new InternalAuthenticationProvider(null, null, null, null)
+    // hashs of 'password'
+    def VALID_BCRYPT_HASHED_PASSWORD = '$2a$13$PfXyvWHogpPZgZjnk2a0eO7wSSNsMZ6DL4x5k8Bk0CK1cwXwMs0de'
+    def VALID_SHA_HASHED_PASSWORD = 'dc9b4c4a06e7dc774e469a16243ff448a02932fd323bb7ecb0ece308d6bb13c964dd7a0b7b99b15dc785004bdb869450f4070a9f83b027af43025149d1bc8f34'
 
+    // hash of 'wrongpassword'
+    def WRONG_SHA_HASHED_PASSWORD = 'bfe2ee0a1bd6ca719f7b6855eaa2ce166e9f06678a662accac9b8f84ba84801d7f76c7c9a05d5207301fee9a6a11d3178eb34c47647835e7f888d3ce6e7935ba'
+
+    def userName = 'userName'
+    def password = 'password'
+    def userId = '618b398c-0110-43f2-95df-d1bc4e7d2b4a'
+
+    def userProvisioning = Mock(SCIMUserProvisioning)
+    def bCryptPasswordEncoder = new BCryptPasswordEncoder(13)
+
+    @Shared
+    def shaPasswordEncoder = new ShaPasswordEncoder(512)
+
+    InternalAuthenticationProvider provider =
+            new InternalAuthenticationProvider(userProvisioning, shaPasswordEncoder, bCryptPasswordEncoder, 1, null)
+
+    def setupSpec() {
+        shaPasswordEncoder.iterations = 1000
+    }
+
+    def 'the internal provider only supports InternalAuthentication class'() {
         expect:
         provider.supports(InternalAuthentication)
+    }
+
+    def 'successful authentication with bcrypt hash is possible'() {
+        given:
+        User user = new User.Builder(userName)
+                .setPassword(VALID_BCRYPT_HASHED_PASSWORD)
+                .setId(userId)
+                .setActive(true)
+                .build()
+        InternalAuthentication authentication = new InternalAuthentication(userName, password)
+        userProvisioning.getByUsernameWithPassword(_) >> user
+
+        when:
+        Authentication successfulAuthentication = provider.authenticate(authentication)
+
+        then:
+        ((User) successfulAuthentication.principal).userName == userName
+    }
+
+    def 'successful authentication with sha hash is possible and replaces user'() {
+        given:
+        User user = new User.Builder(userName)
+                .setPassword(VALID_SHA_HASHED_PASSWORD)
+                .setId(userId)
+                .setActive(true)
+                .build()
+        InternalAuthentication authentication = new InternalAuthentication(userName, password)
+        userProvisioning.getByUsernameWithPassword(_) >> user
+        User replaceUser = new User.Builder(user).setPassword(password).build();
+
+        when:
+        Authentication successfulAuthentication = provider.authenticate(authentication)
+
+        then:
+        1 * userProvisioning.replace(user.getId(), replaceUser);
+        ((User) successfulAuthentication.principal).userName == userName
+    }
+
+    def 'authentication with wrong sha hash fails'() {
+        given:
+        User user = new User.Builder(userName)
+                .setPassword(WRONG_SHA_HASHED_PASSWORD)
+                .setId(userId)
+                .setActive(true)
+                .build()
+        InternalAuthentication authentication = new InternalAuthentication(userName, password)
+        userProvisioning.getByUsernameWithPassword(_) >> user
+
+        when:
+        provider.authenticate(authentication)
+
+        then:
+        thrown(BadCredentialsException)
     }
 }

--- a/src/test/groovy/org/osiam/resources/provisioning/UserDeleteSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/UserDeleteSpec.groovy
@@ -27,17 +27,18 @@ import org.osiam.resources.converter.UserConverter
 import org.osiam.resources.exception.ResourceNotFoundException
 import org.osiam.storage.dao.UserDao
 import org.springframework.security.authentication.encoding.PasswordEncoder
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import spock.lang.Specification
 
 import javax.persistence.NoResultException
 
 class UserDeleteSpec extends Specification {
 
-    def passwordEncoder = Mock(PasswordEncoder)
+    def bCryptPasswordEncoder = Mock(BCryptPasswordEncoder)
     def userDao = Mock(UserDao)
     def userConverter = Mock(UserConverter)
 
-    SCIMUserProvisioning scimUserProvisioning = new SCIMUserProvisioning(userConverter, userDao, passwordEncoder, null)
+    SCIMUserProvisioning scimUserProvisioning = new SCIMUserProvisioning(userConverter, userDao, bCryptPasswordEncoder, null)
 
     def uuidAsString = UUID.randomUUID().toString()
 

--- a/src/test/groovy/org/osiam/resources/provisioning/update/UserUpdaterSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/update/UserUpdaterSpec.groovy
@@ -30,7 +30,7 @@ import org.osiam.resources.scim.Meta
 import org.osiam.resources.scim.User
 import org.osiam.storage.dao.UserDao
 import org.osiam.storage.entities.UserEntity
-import org.springframework.security.authentication.encoding.PasswordEncoder
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -38,18 +38,18 @@ class UserUpdaterSpec extends Specification {
 
     static IRRELEVANT = 'irrelevant'
 
-    NameUpdater nameUpdater = Mock()
-    EmailUpdater emailUpdater = Mock()
-    PhoneNumberUpdater phoneNumberUpdater = Mock()
-    ImUpdater imUpdater = Mock()
-    PhotoUpdater photoUpdater = Mock()
-    EntitlementsUpdater entitlementUpdater = Mock()
-    RoleUpdater roleUpdater = Mock()
-    X509CertificateUpdater x509CertificateUpdater = Mock()
-    AddressUpdater addressUpdater = Mock()
-    UserDao userDao = Mock()
-    PasswordEncoder passwordEncoder = Mock()
-    ExtensionUpdater extensionUpdater = Mock()
+    def nameUpdater = Mock(NameUpdater)
+    def emailUpdater = Mock(EmailUpdater)
+    def phoneNumberUpdater = Mock(PhoneNumberUpdater)
+    def imUpdater = Mock(ImUpdater)
+    def photoUpdater = Mock(PhotoUpdater)
+    def entitlementUpdater = Mock(EntitlementsUpdater)
+    def roleUpdater = Mock(RoleUpdater)
+    def x509CertificateUpdater = Mock(X509CertificateUpdater)
+    def addressUpdater = Mock(AddressUpdater)
+    def userDao = Mock(UserDao)
+    def bCryptPasswordEncoder = Mock(BCryptPasswordEncoder)
+    def extensionUpdater = Mock(ExtensionUpdater)
 
     ResourceUpdater resourceUpdater = Mock()
     UserUpdater userUpdater = new UserUpdater(userDao,
@@ -63,11 +63,11 @@ class UserUpdaterSpec extends Specification {
             roleUpdater,
             x509CertificateUpdater,
             addressUpdater,
-            passwordEncoder,
+            bCryptPasswordEncoder,
             extensionUpdater)
 
     User user
-    UserEntity userEntity = Mock()
+    def userEntity = Mock(UserEntity)
 
     def 'updating a user triggers resource updater'() {
         given:
@@ -607,15 +607,13 @@ class UserUpdaterSpec extends Specification {
 
     def 'updating the password is possible'() {
         given:
-        def uuid = UUID.randomUUID()
         User user = new User.Builder(password: IRRELEVANT).build()
 
         when:
         userUpdater.update(user, userEntity)
 
         then:
-        1 * userEntity.getId() >> uuid
-        1 * passwordEncoder.encodePassword(IRRELEVANT, uuid) >> 'hashedPassword'
+        1 * bCryptPasswordEncoder.encode(IRRELEVANT) >> 'hashedPassword'
         1 * userEntity.setPassword('hashedPassword')
     }
 


### PR DESCRIPTION
When users login, their passwords will be updated to the new BCrypt hashes.
Until the Release 4.0 the old sha password hashes will be supported.
After OSIAM 4.0 was released the old password hashes are not usable anymore.

Resolves #34
