### PR TITLE
Clean up documentation

### DIFF
--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -161,7 +161,7 @@ by using the following command:
 
 Everything is fine when you see a JSON string as response that looks like this:
 
-    {"schemas":["urn:scim:schemas:core:1.0"],"patch":{"supported":true},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
+    {"schemas":["urn:scim:schemas:core:2.0:User"],"patch":{"supported":true},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
     
 ## Default setup
 


### PR DESCRIPTION
One old schema slipped through in the documentation. This pull request cleans that up. It closes #87
