### PR TITLE
Add deploy resources to `spring-boot:run`'s classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,9 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <finalName>osiam</finalName>
+                    <folders>
+                        <folder>src/main/deploy</folder>
+                    </folders>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Allow starting of OSIAM for development purposes on the command line
using `mvn spring-boot:run' by adding deploy resources to classpath.
