### PR TITLE
Never return null as ClientDetails

### DIFF
--- a/src/main/java/org/osiam/security/authentication/OsiamClientDetailsService.java
+++ b/src/main/java/org/osiam/security/authentication/OsiamClientDetailsService.java
@@ -23,10 +23,13 @@
 
 package org.osiam.security.authentication;
 
+import org.osiam.auth.oauth_client.ClientEntity;
 import org.osiam.auth.oauth_client.ClientRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.method.P;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.NoSuchClientException;
 import org.springframework.stereotype.Service;
 
 /**
@@ -40,6 +43,13 @@ public class OsiamClientDetailsService implements ClientDetailsService {
 
     @Override
     public ClientDetails loadClientByClientId(final String clientId) {
-        return clientRepository.findById(clientId);
+        ClientEntity client = clientRepository.findById(clientId);
+        if(client == null) {
+            throw new NoSuchClientException(String.format(
+                    "OsiamClientDetailsService failed to load client with id %s: no client found",
+                    clientId
+            ));
+        }
+        return client;
     }
 }


### PR DESCRIPTION
The Javadoc of `ClientDetailsService#loadClientByClientId` states that it should never return null [1].
Change the current implementation to fulfill this contract. Instead a `NoSuchClientException` will be thrown, which will be consistently handled by the framework.

[1] https://github.com/spring-projects/spring-security-oauth/blob/2.0.8.RELEASE/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ClientDetailsService.java#L28
