### PR TITLE
Refactor configuration of client credentials grant

### DIFF
--- a/src/main/java/org/osiam/configuration/OAuth2AuthorizationServerConfig.java
+++ b/src/main/java/org/osiam/configuration/OAuth2AuthorizationServerConfig.java
@@ -29,7 +29,6 @@ import org.osiam.security.authentication.OsiamClientDetailsService;
 import org.osiam.security.authorization.OsiamUserApprovalHandler;
 import org.osiam.security.helper.LessStrictRedirectUriAuthorizationCodeTokenGranter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -37,6 +36,7 @@ import org.springframework.security.oauth2.config.annotation.configurers.ClientD
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.CompositeTokenGranter;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.TokenGranter;
@@ -78,6 +78,11 @@ public class OAuth2AuthorizationServerConfig extends AuthorizationServerConfigur
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
         clients.withClientDetails(osiamClientDetailsService).build();
+    }
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+        security.allowFormAuthenticationForClients();
     }
 
     @Bean


### PR DESCRIPTION
Use `spring-security-oauth2`'s ability to add the `ClientCredentialsTokenEndpointFilter` by itself in `OAuth2AuthorizationServerConfig`, therefore remove the addition of the `ClientCredentialsTokenEndpointFilter` in `OAuth2ClientCredentialsSecurity`.

Rename `OAuth2ClientCredentialsSecurity` to `FacebookClientCredentialsSecurity`, because now it only handles the client credentials grant that mimics Facebook's OAuth 2 procces. Set the basic security defaults in `FacebookClientCredentialsSecurity` as they haven't been there before. Set an @Order of 1 to `FacebookClientCredentialsSecurity`, because it has to consulted before the REST security filter chain (3) but after the authorization server security filter chain (0).
