### PR TITLE
Allow colons (:) as field separators for URNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
     clients and then add the new scopes `ADMIN` and `ME`. See the
     [migration notes] (docs/Migration.md#from-22-to-30) for further details.
 
+- Allow colons (:) as field separators for URNs of extensions, since this is
+  what the SCIM specification defines. Using periods (.) is still possible,
+  but will log a warning message. 
+
+- Fields of the core schemas for user and group can be fully qualified, i.e.
+  `filter=urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"` 
+
 - All invalid search queries now respond with a `400 BAD REQUEST` instead of
   `409 CONFLICT` status code.
 - Respond with `401 UNAUTHORIZED` when revoking or validating an access token

--- a/src/main/java/org/osiam/storage/query/EvalVisitor.java
+++ b/src/main/java/org/osiam/storage/query/EvalVisitor.java
@@ -59,27 +59,27 @@ public class EvalVisitor<T extends ResourceEntity> extends LogicalOperatorRulesB
 
     @Override
     public Predicate visitSimpleExp(@NotNull LogicalOperatorRulesParser.SimpleExpContext ctx) {
-        ScimExpression scimExpression = getScimExpressionFromContext(ctx);
-        FilterChain<T> filterChain = filterParser.createFilterChain(scimExpression);
+        FilterExpression<T> filterExpression = getFilterExpressionFromContext(ctx);
+        FilterChain<T> filterChain = filterParser.createFilterChain(filterExpression);
         return filterChain.createPredicateAndJoin(root);
     }
 
-    private ScimExpression getScimExpressionFromContext(LogicalOperatorRulesParser.SimpleExpContext ctx) {
+    private FilterExpression<T> getFilterExpressionFromContext(LogicalOperatorRulesParser.SimpleExpContext ctx) {
         String fieldName = ctx.FIELD().getText();
         String value = ctx.VALUE().getText();
         value = value.substring(1, value.length() - 1); // removed first and last quote
         value = value.replace("\\\"", "\""); // replaced \" with "
         FilterConstraint operator = FilterConstraint.fromString(ctx.OPERATOR().getText());
-        return new ScimExpression(fieldName, operator, value);
+        return filterParser.createFilterExpression(fieldName, operator, value);
     }
 
     @Override
     public Predicate visitSimplePresentExp(@NotNull LogicalOperatorRulesParser.SimplePresentExpContext ctx) {
         String fieldName = ctx.FIELD().getText();
         FilterConstraint operator = FilterConstraint.fromString(ctx.PRESENT().getText());
-        ScimExpression scimExpression = new ScimExpression(fieldName, operator, null);
+        FilterExpression<T> filterExpression = filterParser.createFilterExpression(fieldName, operator, null);
 
-        FilterChain<T> filterChain = filterParser.createFilterChain(scimExpression);
+        FilterChain<T> filterChain = filterParser.createFilterChain(filterExpression);
         return filterChain.createPredicateAndJoin(root);
     }
 

--- a/src/main/java/org/osiam/storage/query/FilterExpression.java
+++ b/src/main/java/org/osiam/storage/query/FilterExpression.java
@@ -23,24 +23,19 @@
 
 package org.osiam.storage.query;
 
-/**
- * Representation of scim search expression.
- */
-public class ScimExpression {
+import org.osiam.storage.entities.ResourceEntity;
 
-    private final String field;
+public abstract class FilterExpression<T extends ResourceEntity> {
+
     private final FilterConstraint constraint;
     private final String value;
 
-    public ScimExpression(String field, FilterConstraint constraint, String value) {
-        this.field = field;
+    public FilterExpression(FilterConstraint constraint, String value) {
         this.constraint = constraint;
         this.value = value;
     }
 
-    public String getField() {
-        return field;
-    }
+    public abstract Field<T> getField();
 
     public FilterConstraint getConstraint() {
         return constraint;
@@ -48,5 +43,16 @@ public class ScimExpression {
 
     public String getValue() {
         return value;
+    }
+
+    public interface Field<T extends ResourceEntity> {
+
+        String getUrn();
+
+        String getName();
+
+        QueryField<T> getQueryField();
+
+        boolean isExtension();
     }
 }

--- a/src/main/java/org/osiam/storage/query/FilterParser.java
+++ b/src/main/java/org/osiam/storage/query/FilterParser.java
@@ -23,14 +23,14 @@
 
 package org.osiam.storage.query;
 
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.osiam.storage.entities.ResourceEntity;
+
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.osiam.storage.entities.ResourceEntity;
 
 public abstract class FilterParser<T extends ResourceEntity> {
 
@@ -53,8 +53,10 @@ public abstract class FilterParser<T extends ResourceEntity> {
         return filterField.createSortByField(root, entityManager.getCriteriaBuilder());
     }
 
+    public abstract FilterExpression<T> createFilterExpression(String field, FilterConstraint constraint, String value);
+
     protected abstract QueryField<T> getFilterField(String sortBy);
 
-    protected abstract FilterChain<T> createFilterChain(ScimExpression filter);
+    protected abstract FilterChain<T> createFilterChain(FilterExpression<T> filter);
 
 }

--- a/src/main/java/org/osiam/storage/query/GroupFilterExpression.java
+++ b/src/main/java/org/osiam/storage/query/GroupFilterExpression.java
@@ -1,0 +1,67 @@
+package org.osiam.storage.query;
+
+import org.osiam.resources.scim.Group;
+import org.osiam.storage.entities.GroupEntity;
+
+import java.util.Locale;
+
+public class GroupFilterExpression extends FilterExpression<GroupEntity> {
+
+    private final Field field;
+
+    public GroupFilterExpression(String field, FilterConstraint constraint, String value) {
+        super(constraint, value);
+        this.field = new Field(field);
+    }
+
+    @Override
+    public Field getField() {
+        return field;
+    }
+
+    public static class Field implements FilterExpression.Field<GroupEntity> {
+        private String name;
+        private QueryField<GroupEntity> queryField;
+
+        public Field(String field) {
+
+            if (field.toLowerCase().startsWith(Group.SCHEMA.toLowerCase())) {
+                if (field.charAt(Group.SCHEMA.length()) == '.') {
+                    throw new IllegalArgumentException(String.format("Period (.) is not a valid field separator: %s", field));
+                }
+
+                name = field.substring(Group.SCHEMA.length() + 1).toLowerCase(Locale.ENGLISH);
+
+            } else {
+                name = field.toLowerCase(Locale.ENGLISH);
+            }
+            queryField = GroupQueryField.fromString(name);
+
+            if (queryField == null) {
+                throw new IllegalArgumentException(String.format("Unable to parse %s, extensions not supported for groups",
+                        field));
+            }
+        }
+
+        @Override
+        public String getUrn() {
+            // We are not supporting Group extensions at the moment.
+            return Group.SCHEMA;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public QueryField<GroupEntity> getQueryField() {
+            return queryField;
+        }
+
+        @Override
+        public boolean isExtension() {
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/osiam/storage/query/GroupFilterParser.java
+++ b/src/main/java/org/osiam/storage/query/GroupFilterParser.java
@@ -23,22 +23,27 @@
 
 package org.osiam.storage.query;
 
-import java.util.Locale;
-
 import org.osiam.storage.entities.GroupEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Locale;
 
 @Service
 public class GroupFilterParser extends FilterParser<GroupEntity> {
 
     @Override
-    protected FilterChain<GroupEntity> createFilterChain(ScimExpression filter) {
-        return new GroupSimpleFilterChain(entityManager.getCriteriaBuilder(), filter);
+    public GroupFilterExpression createFilterExpression(String field, FilterConstraint constraint, String value) {
+        return new GroupFilterExpression(field, constraint, value);
     }
 
     @Override
-    protected QueryField<GroupEntity> getFilterField(String sortBy) {
+    protected GroupQueryField getFilterField(String sortBy) {
         return GroupQueryField.fromString(sortBy.toLowerCase(Locale.ENGLISH));
+    }
+
+    @Override
+    protected GroupSimpleFilterChain createFilterChain(FilterExpression<GroupEntity> filter) {
+        return new GroupSimpleFilterChain(entityManager.getCriteriaBuilder(), filter);
     }
 
 }

--- a/src/main/java/org/osiam/storage/query/GroupSimpleFilterChain.java
+++ b/src/main/java/org/osiam/storage/query/GroupSimpleFilterChain.java
@@ -23,35 +23,27 @@
 
 package org.osiam.storage.query;
 
-import java.util.Locale;
+import org.osiam.storage.entities.GroupEntity;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import org.osiam.storage.entities.GroupEntity;
-
 public class GroupSimpleFilterChain implements FilterChain<GroupEntity> {
 
-    private final ScimExpression scimExpression;
+    private final FilterExpression<GroupEntity> filterExpression;
 
-    private final GroupQueryField filterField;
+    private final QueryField<GroupEntity> filterField;
     private final CriteriaBuilder criteriaBuilder;
 
-    public GroupSimpleFilterChain(CriteriaBuilder criteriaBuilder, ScimExpression scimExpression) {
+    public GroupSimpleFilterChain(CriteriaBuilder criteriaBuilder, FilterExpression<GroupEntity> filterExpression) {
         this.criteriaBuilder = criteriaBuilder;
-        this.scimExpression = scimExpression;
-        filterField = GroupQueryField.fromString(scimExpression.getField().toLowerCase(Locale.ENGLISH));
+        this.filterExpression = filterExpression;
+        filterField = filterExpression.getField().getQueryField();
     }
 
     @Override
     public Predicate createPredicateAndJoin(Root<GroupEntity> root) {
-        if (filterField == null) {
-            throw new IllegalArgumentException(String.format("Unable to filter. Field '%s' not available.",
-                    scimExpression.getField()));
-        }
-
-        return filterField.addFilter(root, scimExpression.getConstraint(), scimExpression.getValue(), criteriaBuilder);
+        return filterField.addFilter(root, filterExpression.getConstraint(), filterExpression.getValue(), criteriaBuilder);
     }
-
 }

--- a/src/main/java/org/osiam/storage/query/UserFilterExpression.java
+++ b/src/main/java/org/osiam/storage/query/UserFilterExpression.java
@@ -1,0 +1,93 @@
+package org.osiam.storage.query;
+
+import org.osiam.resources.scim.User;
+import org.osiam.storage.entities.UserEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+public class UserFilterExpression extends FilterExpression<UserEntity> {
+
+    private Field field;
+
+    UserFilterExpression(String field, FilterConstraint constraint, String value) {
+        super(constraint, value);
+        this.field = new Field(field);
+    }
+
+    @Override
+    public UserFilterExpression.Field getField() {
+        return field;
+    }
+
+    public static class Field implements FilterExpression.Field<UserEntity> {
+        private static final Logger logger = LoggerFactory.getLogger(UserFilterExpression.Field.class);
+        private String urn;
+        private String name;
+        private UserQueryField queryField;
+
+        public Field(String field) {
+            if (field.toLowerCase().startsWith(User.SCHEMA.toLowerCase())) {
+                if (field.charAt(User.SCHEMA.length()) == '.') {
+                    throw new IllegalArgumentException(String.format("Period (.) is not a valid field separator: %s", field));
+                }
+                name = field.substring(User.SCHEMA.length() + 1).toLowerCase(Locale.ENGLISH);
+            } else {
+                name = field.toLowerCase(Locale.ENGLISH);
+            }
+
+            // Try to resolve a core schema field.
+            queryField = UserQueryField.fromString(name);
+
+            urn = User.SCHEMA;
+            // we can't recognize a core schema field, it's an extension.
+            if (queryField == null) {
+
+                // lastIndexOf returns -1 if char can not be found in the string
+                int lastIndexOfPeriod = field.lastIndexOf('.');
+                int lastIndexOfColon = field.lastIndexOf(':');
+
+                // the last string part of the string is separated by a period, that is not SCIM conform but has been
+                // supported by OSIAM for a long time so we generate a warning. As soon as we support extended attributes
+                // for extensions this needs to go.
+                if (lastIndexOfPeriod > lastIndexOfColon) {
+                    urn = field.substring(0, lastIndexOfPeriod);
+                    name = field.substring(lastIndexOfPeriod + 1);
+                    logger.warn(
+                            String.format("Period (.) used as field separator in %s. This is not SCIM conform and deprecated!",
+                                    field));
+                } else if (lastIndexOfColon > lastIndexOfPeriod) {
+                    // a colon is separating the last part of this string and the field of the extension from it's URN.
+                    // Just as it's supposed to be.
+                    urn = field.substring(0, lastIndexOfColon);
+                    name = field.substring(lastIndexOfColon + 1);
+                } else {
+                    // Neither colon nor period found in string. It's a user error.
+                    throw new IllegalArgumentException(String.format("Unable to parse field or extension from %s",
+                            field));
+                }
+            }
+        }
+
+        @Override
+        public String getUrn() {
+            return urn;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public UserQueryField getQueryField() {
+            return queryField;
+        }
+
+        @Override
+        public boolean isExtension() {
+            return queryField == null;
+        }
+    }
+}

--- a/src/main/java/org/osiam/storage/query/UserFilterParser.java
+++ b/src/main/java/org/osiam/storage/query/UserFilterParser.java
@@ -41,8 +41,8 @@ public class UserFilterParser extends FilterParser<UserEntity> {
     }
 
     @Override
-    protected FilterChain<UserEntity> createFilterChain(ScimExpression filter) {
-        return new UserSimpleFilterChain(entityManager.getCriteriaBuilder(), extensionDao, filter);
+    public FilterExpression<UserEntity> createFilterExpression(String field, FilterConstraint constraint, String value) {
+        return new UserFilterExpression(field, constraint, value);
     }
 
     @Override
@@ -50,4 +50,8 @@ public class UserFilterParser extends FilterParser<UserEntity> {
         return UserQueryField.fromString(sortBy.toLowerCase(Locale.ENGLISH));
     }
 
+    @Override
+    protected UserSimpleFilterChain createFilterChain(FilterExpression<UserEntity> filter) {
+        return new UserSimpleFilterChain(entityManager.getCriteriaBuilder(), extensionDao, filter);
+    }
 }

--- a/src/main/java/org/osiam/storage/query/UserQueryField.java
+++ b/src/main/java/org/osiam/storage/query/UserQueryField.java
@@ -867,7 +867,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
     private final String name;
 
-    private UserQueryField(String name) {
+    UserQueryField(String name) {
         this.name = name;
     }
 

--- a/src/test/groovy/org/osiam/storage/query/GroupFilterExpressionSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/query/GroupFilterExpressionSpec.groovy
@@ -1,0 +1,58 @@
+package org.osiam.storage.query
+
+import org.osiam.resources.scim.Group
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GroupFilterExpressionSpec extends Specification {
+
+    @Unroll
+    def 'QueryField "#queryField" can be resolved'() {
+        given:
+        def expression = new GroupFilterExpression("${queryField}", FilterConstraint.EQUALS, 'irrelevant')
+
+        expect:
+        expression.field.queryField.toString() == queryField
+        expression.field.getUrn() == Group.SCHEMA
+        !expression.field.isExtension()
+
+        where:
+        queryField << GroupQueryField.values().collect { it.toString() }
+    }
+
+    @Unroll
+    def 'Resolving fully qualified query field "#queryField"'() {
+        given:
+        def expression = new GroupFilterExpression("${Group.SCHEMA}:${queryField}", FilterConstraint.EQUALS, 'irrelevant')
+
+        expect:
+        expression.field.queryField.toString() == queryField
+        expression.field.getUrn() == Group.SCHEMA
+        !expression.field.isExtension()
+
+        where:
+        queryField << GroupQueryField.values().collect { it.toString() }
+    }
+
+    @Unroll
+    def 'Separating field "#queryField" by period rasises an exception'() {
+        when:
+        def expression = new GroupFilterExpression("${Group.SCHEMA}.${queryField}", FilterConstraint.EQUALS, 'irrelevant')
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        queryField << GroupQueryField.values().collect { it.toString() }
+    }
+
+    def 'Querying for group extension raises exception'() {
+        when:
+        new GroupFilterExpression("urn:field", FilterConstraint.EQUALS, 'irrelevant')
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+
+}

--- a/src/test/groovy/org/osiam/storage/query/UserFilterExpressionSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/query/UserFilterExpressionSpec.groovy
@@ -1,0 +1,91 @@
+package org.osiam.storage.query
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.spi.AppenderAttachable
+import org.osiam.resources.scim.User
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class UserFilterExpressionSpec extends Specification {
+
+    @Unroll
+    def 'QueryField "#queryField" can be resolved'() {
+        given:
+        def expression = new UserFilterExpression("${queryField}", FilterConstraint.EQUALS, 'irrelevant')
+
+        expect:
+        expression.field.queryField.toString() == queryField
+        expression.field.getUrn() == User.SCHEMA
+        !expression.field.isExtension()
+
+        where:
+        queryField << UserQueryField.values().collect { it.toString() }
+    }
+
+    @Unroll
+    def 'Adding the core schema manually to field "#queryField" works'() {
+        given:
+        def expression = new UserFilterExpression("${User.SCHEMA}:${queryField}", FilterConstraint.CONTAINS, 'irrelewant')
+
+        expect:
+        expression.field.queryField.toString() == queryField
+        expression.field.getUrn() == User.SCHEMA
+        !expression.field.isExtension()
+
+        where:
+        queryField << UserQueryField.values().collect { it.toString() }
+    }
+
+    @Unroll
+    def 'Field separated by "#separator" can be located'() {
+        given:
+        def expression = new UserFilterExpression("urn${separator}field", FilterConstraint.EQUALS, 'irrelevant')
+
+        expect:
+        expression.field.name == 'field'
+        expression.field.isExtension()
+
+        where:
+        separator << [".", ":"]
+    }
+
+    def 'Field without urn is located'() {
+        given:
+        def expression = new UserFilterExpression('displayname', FilterConstraint.EQUALS, 'irrelevant')
+
+        expect:
+        expression.field.name == 'displayname'
+    }
+
+    @Unroll
+    def 'Separating field "#queryField" by period rasises an exception'() {
+        when:
+        def expression = new UserFilterExpression("${User.SCHEMA}.${queryField}", FilterConstraint.EQUALS, 'irrelevant')
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        queryField << UserQueryField.values().collect { it.toString() }
+    }
+    def 'Make sure warning is logged if field is separated by a period'() {
+        given:
+        def appender = Mock(Appender)
+        def rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)
+        ((AppenderAttachable<ILoggingEvent>) rootLogger).addAppender(appender)
+
+        when:
+        def expression = new UserFilterExpression("urn.field", FilterConstraint.EQUALS, "irrelevant")
+
+        then:
+        expression.field.name == 'field'
+        expression.field.urn == 'urn'
+        1 * appender.doAppend({
+            it.message == 'Period (.) used as field separator in urn.field. This is not SCIM conform and deprecated!'
+        })
+    }
+}


### PR DESCRIPTION
The scim specification uses colons (:) to separate fields from the rest
of an URN. OSIAM, until now used periods (.) this commit fixes that.
Using periods to separate fields from URNs is still possible, but a
warning is generated informing the user that this is not SCIM conform.

This fixes #94
