### PR TITLE
Raise required Java version to Java 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Require a Java runtime enviroment of at least version 8
+
 - Remove usage of old, method-based OAuth scopes
 - Remove support for old, method-based OAuth scopes
 - Add Flyway migration to replace method-based scopes

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  java:
+   version: oraclejdk8
+
 dependencies:
   override:
     - mvn -U dependency:resolve dependency:resolve-plugins

--- a/docs/OSIAM-Overview.md
+++ b/docs/OSIAM-Overview.md
@@ -195,12 +195,12 @@ production, please let us known by creating a [ticket]
 
 OSIAM is based on Java technology utilizing parts of the Spring framework. It
 is in general independent of the platform it runs on as long as the proper Java
-environment is in place. We are supporting both OpenJDK 7 and Oracle Java 7.
+environment is in place. We are supporting both OpenJDK 8 and Oracle Java 8.
 
 ### Operating System
 
 OSIAM has been up and running under various operating system (Fedora, CentOS,
-Windows, Debian) utilizing their available Java 7 stack.
+Windows, Debian) utilizing their available Java 8 stack.
 
 ### Databases
 

--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -29,11 +29,11 @@ This document takes the following prerequisites as basis:
     <dt>Operating Systems</dt>
     <dd>Any OS that supports running Java applications</dd>
     <dt>Runtime Environment</dt>
-    <dd>Java 7, OpenJDK 7 JRE</dd>
+    <dd>Java 8, OpenJDK 8 JRE</dd>
     <dt>Application Server</dt>
     <dd>Tomcat 7</dd>
     <dt>Database</dt>
-    <dd>PostgreSQL 9.3 or MySQL 5.7</dd>
+    <dd>PostgreSQL 9.4 or MySQL 5.7</dd>
 </dl>
 
 All of the items have to be installed and running. For the installation of OSIAM

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         OSIAM is a secure identity management solution providing REST based services for authentication and authorization. We achieve this by implementing two important open standards:
 
         * OAuth 2.0
-        * SCIM v2 (still in draft phase)
+        * SCIM 2.0
 
         OSIAM is published under the MIT licence, giving you the greatest freedom possible to utilize OSIAM in you project or product.
     </description>
@@ -90,7 +90,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <start-class>org.osiam.Osiam</start-class>
 
         <sonar.core.codeCoveragePlugin>cobertura</sonar.core.codeCoveragePlugin>
@@ -222,7 +222,7 @@
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
-            <version>3.1</version>
+            <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,12 +233,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-            <version>3.1</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>


### PR DESCRIPTION
This PR raises the minimally required version of Java to 8. It updates the pom and the documentation, including the `CHANGELOG.md` but doesn't change any code yet. I intend to do that in other PRs to keep them managable. This closes #10.
