### PR TITLE
Skip generated classes and migrations for coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,11 @@
                     <dataFile>${project.build.directory}/coverage-reports/jacoco.exec</dataFile>
                     <destFile>${project.build.directory}/coverage-reports/jacoco.exec</destFile>
                     <outputDirectory>${project.build.directory}/coverage-reports/jacoco/</outputDirectory>
+                    <excludes>
+                        <exclude>**/*_.*</exclude>
+                        <exclude>**/storage/parser/**</exclude>
+                        <exclude>**/db/migration/**</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Ignore generated files and database schema migrations when generating
test coverage reports.
