### PR TITLE
Use coveralls.io for test coverage reporting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ test:
     - sudo sh jpmInstall.sh
     - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
     - codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
+    - mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN
 
 deployment:
  staging:

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,16 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <configuration>
+                    <jacocoReports>
+                        <entry>${project.build.directory}/coverage-reports/jacoco/jacoco.xml</entry>
+                    </jacocoReports>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
This pull request adds [coveralls.io](https://coveralls.io) support to
the project to track test coverage reporting.
