### PR TITLE
Fix reporting of test coverage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,9 @@ machine:
 dependencies:
   override:
     - mvn -U dependency:resolve dependency:resolve-plugins
+    - curl http://www.jpm4j.org/install/script > jpmInstall.sh
+    - sudo sh jpmInstall.sh
+    - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
 
 test:
   override:
@@ -13,11 +16,8 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/target/.*-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
     - cp -r target/coverage-reports/jacoco/ $CIRCLE_ARTIFACTS
-    - curl http://www.jpm4j.org/install/script > jpmInstall.sh
-    - sudo sh jpmInstall.sh
-    - sudo jpm install com.codacy:codacy-coverage-reporter:assembly
-    - codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
-    - mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN
+    - test -z $CODACY_PROJECT_TOKEN || codacy-coverage-reporter -l Java -r target/coverage-reports/jacoco/jacoco.xml --projectToken $CODACY_PROJECT_TOKEN
+    - test -z $COVERALLS_REPO_TOKEN || mvn coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN
 
 deployment:
  staging:


### PR DESCRIPTION
The environent variables set in circleci are not available when building pull requests, so this pull request makes sure we don't try to report test coverage data to external systems because we would not be able to get our data there.
