### PR TITLE
Remove unneeded attributes from login template

### DIFF
--- a/src/main/deploy/osiam/templates/web/login.html
+++ b/src/main/deploy/osiam/templates/web/login.html
@@ -41,8 +41,7 @@
                 <h2 class="form-signin-heading" th:text="#{login.headline}">
                      Please sign in
                 </h2>
-                <div th:if="${errorKey}" id="errorMsg" th:error="${errorKey}"
-                     th:class="'alert alert-danger'" class="alert alert-danger" th:text="#{${errorKey}(${templockTimeout})}">
+                <div th:if="${errorKey}" id="errorMsg" class="alert alert-danger" th:text="#{${errorKey}(${templockTimeout})}">
                     Login error
                 </div>
             </div>


### PR DESCRIPTION
`th:error` isn't even a valid Thymeleaf attribute and `th:class` is set
to a literal string that is the same as in `class`.
