### PR TITLE
Refactor LoginController

### DIFF
--- a/src/main/java/org/osiam/security/controller/LoginController.java
+++ b/src/main/java/org/osiam/security/controller/LoginController.java
@@ -23,17 +23,23 @@
 
 package org.osiam.security.controller;
 
+import com.google.common.base.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpSession;
+import java.util.Optional;
 
 @Controller
 @RequestMapping("/login")
 public class LoginController {
+
+    private static final String SESSION_ERROR_KEY = "ERROR_KEY";
+    private static final String MODEL_ERROR_KEY = "errorKey";
 
     @Autowired
     private HttpSession session;
@@ -45,29 +51,44 @@ public class LoginController {
     private int templockTimeout;
 
     @RequestMapping
-    public String login(Model model) {
-        model.addAttribute("isLdapConfigured", isLdapConfigured);
-
-        if (userIsLocked()) {
-            model.addAttribute("locked", true);
-        }
-
+    public String login() {
         return "login";
     }
 
     @RequestMapping("/error")
-    public String loginError(Model model, Exception e) {
-        model.addAttribute("loginError", true);
-        model.addAttribute("isLdapConfigured", isLdapConfigured);
+    public ModelAndView loginError() {
+        ModelAndView modelAndView = new ModelAndView("login");
+        modelAndView.addObject("loginError", true);
 
         if (userIsLocked()) {
-            model.addAttribute("errorKey", "login.lock");
-            model.addAttribute("templockTimeout", templockTimeout);
-        } else {
-            model.addAttribute("errorKey", "login.error");
+            modelAndView.addObject(MODEL_ERROR_KEY, "login.lock");
+            modelAndView.addObject("templockTimeout", templockTimeout);
+            return modelAndView;
         }
 
-        return "login";
+        Optional<String> errorMessageFromSession = getErrorMessageFromSession();
+        if (errorMessageFromSession.isPresent()) {
+            modelAndView.addObject(MODEL_ERROR_KEY, errorMessageFromSession.get());
+            return modelAndView;
+        }
+
+        modelAndView.addObject(MODEL_ERROR_KEY, "login.error");
+        return modelAndView;
+    }
+
+    @ModelAttribute("isLdapConfigured")
+    public boolean isLdapConfigured() {
+        return isLdapConfigured;
+    }
+
+    private Optional<String> getErrorMessageFromSession() {
+        Object attribute = session.getAttribute(SESSION_ERROR_KEY);
+        if (attribute == null || !(attribute instanceof String)) {
+            return Optional.empty();
+        }
+        String errorMessage = (String) attribute;
+        session.removeAttribute(SESSION_ERROR_KEY);
+        return Optional.ofNullable(Strings.emptyToNull(errorMessage));
     }
 
     private boolean userIsLocked() {


### PR DESCRIPTION
`OsiamCachingAuthenticationFailureHandler` sets an LDAP-related error
message in the session.
Passing the message to the view was some kind of magical before: No one
knows how and why it worked.
Explicitly read the error message from the session now and add it to the
model.
Use `ModelAndView` in `/login/error` to simplify error handling.

Extract common model attributes as `@ModelAttribute` annotated methods.
This removes the duplication of setting it.

Model attribute `locked` isn't used by the login template, so remove it.
