### PR TITLE
Reply with 400 BAD REQUEST to invalid filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 
 - Allow colons (:) as field separators for URNs of extensions, since this is
   what the SCIM specification defines. Using periods (.) is still possible,
-  but will log a warning message. 
+  but will log a warning message.
 
 - Fields of the core schemas for user and group can be fully qualified, i.e.
-  `filter=urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"` 
+  `filter=urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"`
 
 - All invalid search queries now respond with a `400 BAD REQUEST` instead of
   `409 CONFLICT` status code.

--- a/src/main/antlr4/org/osiam/storage/parser/LogicalOperatorRules.g4
+++ b/src/main/antlr4/org/osiam/storage/parser/LogicalOperatorRules.g4
@@ -72,3 +72,8 @@ VALUE
 EXCLUDE
     : [\b | \t | \r | \n]+ -> skip //skipping backspaces, tabs, carriage returns and newlines
     ;
+
+
+
+// handle characters which failed to match any other token
+ErrorCharacter : . ;

--- a/src/main/java/org/osiam/resources/exception/InvalidFilterException.java
+++ b/src/main/java/org/osiam/resources/exception/InvalidFilterException.java
@@ -1,0 +1,8 @@
+package org.osiam.resources.exception;
+
+public class InvalidFilterException extends OsiamException {
+
+    public InvalidFilterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
+++ b/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
@@ -55,7 +55,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return produceErrorResponse("An unexpected error occurred", HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler({IllegalArgumentException.class, InvalidConstraintException.class})
+    @ExceptionHandler({IllegalArgumentException.class, InvalidFilterException.class, InvalidConstraintException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
     public ErrorResponse handleInvalidConstraintException(Exception e) {

--- a/src/main/java/org/osiam/storage/helper/NumberPadder.java
+++ b/src/main/java/org/osiam/storage/helper/NumberPadder.java
@@ -56,7 +56,11 @@ public class NumberPadder {
             throw new IllegalArgumentException("The given value has more than " + (PAD_LENGTH - 1) + " digits.");
         }
 
-        integralPart = new BigInteger(integralPart).add(BIG_OFFSET).toString();
+        try {
+            integralPart = new BigInteger(integralPart).add(BIG_OFFSET).toString();
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Unable to parse a number from " + value);
+        }
         integralPart = Strings.padStart(integralPart, PAD_LENGTH, '0');
 
         return integralPart + fractionalPart;

--- a/src/main/java/org/osiam/storage/query/ExtensionQueryField.java
+++ b/src/main/java/org/osiam/storage/query/ExtensionQueryField.java
@@ -23,6 +23,7 @@
 
 package org.osiam.storage.query;
 
+import org.osiam.resources.exception.InvalidFilterException;
 import org.osiam.resources.scim.ExtensionFieldType;
 import org.osiam.storage.entities.*;
 import org.osiam.storage.helper.NumberPadder;
@@ -48,7 +49,11 @@ public class ExtensionQueryField {
         if (constraint != FilterConstraint.PRESENT && (field.getType() == ExtensionFieldType.INTEGER ||
                 field.getType() == ExtensionFieldType.DECIMAL)) {
 
-            value = numberPadder.pad(value);
+            try {
+                value = numberPadder.pad(value);
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidFilterException(ex.getMessage());
+            }
         }
 
         final SetJoin<UserEntity, ExtensionFieldValueEntity> join = createOrGetJoin(

--- a/src/main/java/org/osiam/storage/query/FilterParser.java
+++ b/src/main/java/org/osiam/storage/query/FilterParser.java
@@ -24,6 +24,7 @@
 package org.osiam.storage.query;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.osiam.resources.exception.InvalidFilterException;
 import org.osiam.storage.entities.ResourceEntity;
 
 import javax.persistence.EntityManager;
@@ -47,7 +48,7 @@ public abstract class FilterParser<T extends ResourceEntity> {
         QueryField<T> filterField = getFilterField(sortBy);
 
         if (filterField == null) {
-            throw new IllegalArgumentException("Sorting by " + sortBy + " is not suported.");
+            throw new InvalidFilterException("Sorting by " + sortBy + " is not suported.");
         }
 
         return filterField.createSortByField(root, entityManager.getCriteriaBuilder());

--- a/src/main/java/org/osiam/storage/query/GroupFilterExpression.java
+++ b/src/main/java/org/osiam/storage/query/GroupFilterExpression.java
@@ -1,5 +1,6 @@
 package org.osiam.storage.query;
 
+import org.osiam.resources.exception.InvalidFilterException;
 import org.osiam.resources.scim.Group;
 import org.osiam.storage.entities.GroupEntity;
 
@@ -27,7 +28,7 @@ public class GroupFilterExpression extends FilterExpression<GroupEntity> {
 
             if (field.toLowerCase().startsWith(Group.SCHEMA.toLowerCase())) {
                 if (field.charAt(Group.SCHEMA.length()) == '.') {
-                    throw new IllegalArgumentException(String.format("Period (.) is not a valid field separator: %s", field));
+                    throw new InvalidFilterException(String.format("Period (.) is not a valid field separator: %s", field));
                 }
 
                 name = field.substring(Group.SCHEMA.length() + 1).toLowerCase(Locale.ENGLISH);
@@ -38,7 +39,7 @@ public class GroupFilterExpression extends FilterExpression<GroupEntity> {
             queryField = GroupQueryField.fromString(name);
 
             if (queryField == null) {
-                throw new IllegalArgumentException(String.format("Unable to parse %s, extensions not supported for groups",
+                throw new InvalidFilterException(String.format("Unable to parse %s, extensions not supported for groups",
                         field));
             }
         }

--- a/src/main/java/org/osiam/storage/query/OsiamAntlrErrorListener.java
+++ b/src/main/java/org/osiam/storage/query/OsiamAntlrErrorListener.java
@@ -23,10 +23,7 @@
 
 package org.osiam.storage.query;
 
-import java.util.BitSet;
-
 import org.antlr.v4.runtime.ANTLRErrorListener;
-import org.antlr.v4.runtime.InputMismatchException;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -34,6 +31,9 @@ import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.misc.Nullable;
+import org.osiam.resources.exception.InvalidFilterException;
+
+import java.util.BitSet;
 
 /**
  * Handles parsing errors.
@@ -42,55 +42,52 @@ public class OsiamAntlrErrorListener implements ANTLRErrorListener {
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * The method is overridden to throw an exception if the parsed input has an invalid syntax.
      */
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, @Nullable Object offendingSymbol, int line,
-            int charPositionInLine, String msg, @Nullable RecognitionException e) {
+                            int charPositionInLine, String msg, @Nullable RecognitionException e) {
 
-        String errorMessage = msg;
-        if (e instanceof InputMismatchException && msg.endsWith(" expecting VALUE")) {
-            errorMessage += ". Please make sure that all values are surrounded by double quotes.";
-        }
+        String errorMessage = msg + ". Please make sure that all values are surrounded by double quotes.";
 
-        throw new IllegalArgumentException(errorMessage);
+        throw new InvalidFilterException(errorMessage);
     }
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This is not an error. Its only a report, like a warning.
-     * <p/>
+     * <p>
      * This method is called by the parser when a full-context prediction results in an ambiguity.
      */
     @Override
     public void reportAmbiguity(@NotNull Parser recognizer, @NotNull DFA dfa, int startIndex, int stopIndex,
-            boolean exact, @Nullable BitSet ambigAlts, @NotNull ATNConfigSet configs) {
+                                boolean exact, @Nullable BitSet ambigAlts, @NotNull ATNConfigSet configs) {
     }
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This is not an error. Its only a report, like a warning.
-     * <p/>
+     * <p>
      * This method is called when an SLL conflict occurs and the parser is about to use the full context information to
      * make an LL decision.
      */
     @Override
     public void reportAttemptingFullContext(@NotNull Parser recognizer, @NotNull DFA dfa, int startIndex,
-            int stopIndex, @Nullable BitSet conflictingAlts, @NotNull ATNConfigSet configs) {
+                                            int stopIndex, @Nullable BitSet conflictingAlts, @NotNull ATNConfigSet configs) {
     }
 
     /**
      * {@inheritDoc}
-     * <p/>
+     * <p>
      * This is not an error. Its only a report, like a warning.
-     * <p/>
+     * <p>
      * This method is called by the parser when a full-context prediction has a unique result.
      */
     @Override
     public void reportContextSensitivity(@NotNull Parser recognizer, @NotNull DFA dfa, int startIndex, int stopIndex,
-            int prediction, @NotNull ATNConfigSet configs) {
+                                         int prediction, @NotNull ATNConfigSet configs) {
     }
 }

--- a/src/main/java/org/osiam/storage/query/QueryFilterParser.java
+++ b/src/main/java/org/osiam/storage/query/QueryFilterParser.java
@@ -23,14 +23,12 @@
 
 package org.osiam.storage.query;
 
+import com.google.common.base.Strings;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.osiam.storage.parser.LogicalOperatorRulesLexer;
 import org.osiam.storage.parser.LogicalOperatorRulesParser;
-import org.springframework.stereotype.Service;
-
-import com.google.common.base.Strings;
 
 public class QueryFilterParser {
 
@@ -38,10 +36,15 @@ public class QueryFilterParser {
         if (Strings.isNullOrEmpty(filter)) {
             return null;
         }
+        OsiamAntlrErrorListener errorListener = new OsiamAntlrErrorListener();
 
         LogicalOperatorRulesLexer lexer = new LogicalOperatorRulesLexer(new ANTLRInputStream(filter));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(errorListener);
+
         LogicalOperatorRulesParser parser = new LogicalOperatorRulesParser(new CommonTokenStream(lexer));
-        parser.addErrorListener(new OsiamAntlrErrorListener());
+        parser.removeErrorListeners();
+        parser.addErrorListener(errorListener);
         return parser.parse();
     }
 

--- a/src/main/java/org/osiam/storage/query/UserFilterExpression.java
+++ b/src/main/java/org/osiam/storage/query/UserFilterExpression.java
@@ -1,5 +1,6 @@
 package org.osiam.storage.query;
 
+import org.osiam.resources.exception.InvalidFilterException;
 import org.osiam.resources.scim.User;
 import org.osiam.storage.entities.UserEntity;
 import org.slf4j.Logger;
@@ -30,7 +31,7 @@ public class UserFilterExpression extends FilterExpression<UserEntity> {
         public Field(String field) {
             if (field.toLowerCase().startsWith(User.SCHEMA.toLowerCase())) {
                 if (field.charAt(User.SCHEMA.length()) == '.') {
-                    throw new IllegalArgumentException(String.format("Period (.) is not a valid field separator: %s", field));
+                    throw new InvalidFilterException(String.format("Period (.) is not a valid field separator: %s", field));
                 }
                 name = field.substring(User.SCHEMA.length() + 1).toLowerCase(Locale.ENGLISH);
             } else {
@@ -64,7 +65,7 @@ public class UserFilterExpression extends FilterExpression<UserEntity> {
                     name = field.substring(lastIndexOfColon + 1);
                 } else {
                     // Neither colon nor period found in string. It's a user error.
-                    throw new IllegalArgumentException(String.format("Unable to parse field or extension from %s",
+                    throw new InvalidFilterException(String.format("Unable to parse field or extension from %s",
                             field));
                 }
             }

--- a/src/main/java/org/osiam/storage/query/UserSimpleFilterChain.java
+++ b/src/main/java/org/osiam/storage/query/UserSimpleFilterChain.java
@@ -23,6 +23,7 @@
 
 package org.osiam.storage.query;
 
+import org.osiam.resources.exception.InvalidFilterException;
 import org.osiam.resources.exception.OsiamException;
 import org.osiam.storage.dao.ExtensionDao;
 import org.osiam.storage.entities.ExtensionEntity;
@@ -62,7 +63,8 @@ public class UserSimpleFilterChain implements FilterChain<UserEntity> {
         try {
             extension = extensionDao.getExtensionByUrn(filterExpression.getField().getUrn(), true);
         } catch (OsiamException ex) {
-            throw new IllegalArgumentException(String.format("Filtering not possible. Field '%s' not available.", filterExpression.getField()));
+            throw new InvalidFilterException(String.format("Filtering not possible. Field '%s' not available.",
+                    filterExpression.getField()));
         }
         final ExtensionFieldEntity fieldEntity = extension.getFieldForName(filterExpression.getField().getName(), true);
         return new ExtensionQueryField(filterExpression.getField().getUrn(), fieldEntity);

--- a/src/test/groovy/org/osiam/storage/helper/NumberPadderSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/helper/NumberPadderSpec.groovy
@@ -72,6 +72,15 @@ class NumberPadderSpec extends Specification {
     }
 
     @Unroll
+    def 'trying to pad a value that is not a number raises an exception'() {
+        when:
+        numberPadder.pad('not a number')
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    @Unroll
     def 'unpadding #inputValue results in #expectedValue'() {
         expect:
         numberPadder.unpad(inputValue) == expectedValue

--- a/src/test/groovy/org/osiam/storage/query/GroupFilterExpressionSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/query/GroupFilterExpressionSpec.groovy
@@ -1,5 +1,6 @@
 package org.osiam.storage.query
 
+import org.osiam.resources.exception.InvalidFilterException
 import org.osiam.resources.scim.Group
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -40,7 +41,7 @@ class GroupFilterExpressionSpec extends Specification {
         def expression = new GroupFilterExpression("${Group.SCHEMA}.${queryField}", FilterConstraint.EQUALS, 'irrelevant')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(InvalidFilterException)
 
         where:
         queryField << GroupQueryField.values().collect { it.toString() }
@@ -51,7 +52,7 @@ class GroupFilterExpressionSpec extends Specification {
         new GroupFilterExpression("urn:field", FilterConstraint.EQUALS, 'irrelevant')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(InvalidFilterException)
     }
 
 

--- a/src/test/groovy/org/osiam/storage/query/UserFilterExpressionSpec.groovy
+++ b/src/test/groovy/org/osiam/storage/query/UserFilterExpressionSpec.groovy
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.spi.AppenderAttachable
+import org.osiam.resources.exception.InvalidFilterException
 import org.osiam.resources.scim.User
 import org.slf4j.LoggerFactory
 import spock.lang.Specification
@@ -67,11 +68,12 @@ class UserFilterExpressionSpec extends Specification {
         def expression = new UserFilterExpression("${User.SCHEMA}.${queryField}", FilterConstraint.EQUALS, 'irrelevant')
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(InvalidFilterException)
 
         where:
         queryField << UserQueryField.values().collect { it.toString() }
     }
+
     def 'Make sure warning is logged if field is separated by a period'() {
         given:
         def appender = Mock(Appender)


### PR DESCRIPTION
According to the Scim specification invalid filters should receive a
response wit the status code 400 BAD REQUEST and not 409 CONFLICT. This
is fixed by this commit. It replaces all IllegalArgumentExceptions that
were generated by invalid filters with a InvalidFilterExceptions.

Please be aware that this PR requires the corresponding PR for the
integration tests to be accepted as well. Closes #66
