### PR TITLE
Remove ability to search by a user's password

### DIFF
--- a/src/main/java/org/osiam/storage/query/UserQueryField.java
+++ b/src/main/java/org/osiam/storage/query/UserQueryField.java
@@ -338,18 +338,6 @@ public enum UserQueryField implements QueryField<UserEntity> {
         }
 
     },
-    PASSWORD("password") {
-        @Override
-        public Predicate addFilter(Root<UserEntity> root,
-                FilterConstraint constraint, String value, CriteriaBuilder cb) {
-            return constraint.createPredicateForStringField(root.get(UserEntity_.password), value, cb);
-        }
-
-        @Override
-        public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            throw handleSortByFieldNotSupported(toString());
-        }
-    },
     EMAILS("emails") {
         @Override
         public Predicate addFilter(Root<UserEntity> root, FilterConstraint constraint,


### PR DESCRIPTION
This was needed so that the split auth-server can verify the user's
credentials.
Not needed anymore after the merge.

Resolves #56
