### PR TITLE
Fix URL to service provider config

### DIFF
--- a/docs/OSIAM-Overview.md
+++ b/docs/OSIAM-Overview.md
@@ -140,7 +140,7 @@ list upon implementation.
 <tr><td> /Groups                 </td><td> SCIMv2    </td><td> ADMIN </td><td>                     </td></tr>
 <tr><td> /Bulk                   </td><td> SCIMv2    </td><td> ADMIN                       </td><td> not yet implemented </td></tr>
 <tr><td> /.search                </td><td> SCIMv2    </td><td> ADMIN ME                   </td><td> not yet implemented </td></tr>
-<tr><td> /ServiceProviderConfigs </td><td> SCIMv2    </td><td> public                     </td><td>                     </td></tr>
+<tr><td> /ServiceProviderConfig </td><td> SCIMv2    </td><td> public                     </td><td>                     </td></tr>
 <tr><td> /Schemas                </td><td> SCIMv2    </td><td> public                     </td><td> not yet implemented </td></tr>
 <tr><td> /Clients                </td><td> OSIAM     </td><td> ADMIN </td><td> SCIM based implementation as soon as the standard is defined</td></tr>
 <tr><td> /me                     </td><td> Facebook  </td><td> ADMIN ME                      </td><td>                     </td></tr>

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -367,7 +367,7 @@ The following URI provides the service provider configuration of the addressed
 server:
 
 ```http
-http://OSIAM_HOST:8080/osiam/ServiceProviderConfigs
+http://OSIAM_HOST:8080/osiam/ServiceProviderConfig
 ```
 
 ### Search

--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -119,7 +119,7 @@ Check Tomcat's log files to see the startup progress.
 After some seconds, OSIAM should be fully deployed and ready.
 You can check from the commandline whether OSIAM is started by using the following command:
 
-    $ curl http://localhost:8080/osiam/ServiceProviderConfigs
+    $ curl http://localhost:8080/osiam/ServiceProviderConfig
 
 Everything is fine when you see a JSON string as response that looks like this:
 

--- a/src/main/java/org/osiam/configuration/OAuth2ResourceServerConfig.java
+++ b/src/main/java/org/osiam/configuration/OAuth2ResourceServerConfig.java
@@ -51,7 +51,7 @@ public class OAuth2ResourceServerConfig extends ResourceServerConfigurerAdapter 
     public void configure(HttpSecurity http) throws Exception {
         // @formatter:off
         http.authorizeRequests()
-                .antMatchers("/ServiceProviderConfigs").permitAll()
+                .antMatchers("/ServiceProviderConfig").permitAll()
                 .antMatchers("/me/**").access("#oauth2.hasScope('ADMIN') or #oauth2.hasScope('ME')")
                 .antMatchers(HttpMethod.POST, "/Users/**").access("#oauth2.hasScope('ADMIN')")
                 .regexMatchers(HttpMethod.GET, "/Users/?").access("#oauth2.hasScope('ADMIN')")

--- a/src/main/java/org/osiam/resources/controller/ServiceProviderConfigController.java
+++ b/src/main/java/org/osiam/resources/controller/ServiceProviderConfigController.java
@@ -34,8 +34,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @Controller
-@RequestMapping(value = "/ServiceProviderConfigs")
-public class ServiceProviderConfigsController {
+@RequestMapping(value = "/ServiceProviderConfig")
+public class ServiceProviderConfigController {
 
     @RequestMapping
     @ResponseBody

--- a/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
@@ -26,12 +26,12 @@ package org.osiam.resources.controller
 import spock.lang.Specification
 
 class ServiceProviderConfigSpec extends Specification {
-    def underTest = new ServiceProviderConfigsController()
+    def underTest = new ServiceProviderConfigController()
 
     def "should return a ServiceProviderConfig"() {
         given:
         def schemas = [
-                ServiceProviderConfigsController.ServiceProviderConfig.SCHEMA] as Set
+                ServiceProviderConfigController.ServiceProviderConfig.SCHEMA] as Set
 
         when:
         def config = underTest.getConfig()


### PR DESCRIPTION
The SCIM spec says, that it is "/ServiceProviderConfig" [1] not
"/ServiceProviderConfigs".

[1] https://tools.ietf.org/html/rfc7644#section-4
