### PR TITLE
Make sure core schema is present and valid

### DIFF
--- a/src/main/java/org/osiam/resources/scim/Group.java
+++ b/src/main/java/org/osiam/resources/scim/Group.java
@@ -32,6 +32,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import org.hibernate.validator.constraints.NotBlank;
 import org.osiam.resources.exception.SCIMDataValidationException;
+import org.osiam.resources.validation.ValidCoreSchema;
 
 import javax.validation.Valid;
 import java.io.Serializable;
@@ -110,6 +111,12 @@ public final class Group extends Resource implements Serializable {
         return "Group [displayName=" + displayName + ", members=" + members + ", getId()=" + getId()
                 + ", getExternalId()=" + getExternalId() + ", getMeta()=" + getMeta() + ", getSchemas()="
                 + getSchemas() + "]";
+    }
+
+    @Override
+    @ValidCoreSchema(SCHEMA)
+    public Set<String> getSchemas() {
+        return super.getSchemas();
     }
 
     /**

--- a/src/main/java/org/osiam/resources/scim/Resource.java
+++ b/src/main/java/org/osiam/resources/scim/Resource.java
@@ -24,6 +24,7 @@
 package org.osiam.resources.scim;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.osiam.resources.exception.SCIMDataValidationException;
 
@@ -103,7 +104,7 @@ public abstract class Resource implements Serializable {
      */
     @NotEmpty
     public Set<String> getSchemas() {
-        return schemas;
+        return ImmutableSet.copyOf(schemas);
     }
 
     @Override

--- a/src/main/java/org/osiam/resources/scim/User.java
+++ b/src/main/java/org/osiam/resources/scim/User.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.hibernate.validator.constraints.NotBlank;
 import org.osiam.resources.exception.SCIMDataValidationException;
+import org.osiam.resources.validation.ValidCoreSchema;
 
 import javax.validation.Valid;
 import java.io.Serializable;
@@ -533,6 +534,12 @@ public final class User extends Resource implements Serializable {
                 + groups + ", entitlements=" + entitlements + ", roles=" + roles + ", x509Certificates="
                 + x509Certificates + ", extensions=" + extensions + ", getId()=" + getId() + ", getExternalId()="
                 + getExternalId() + ", getMeta()=" + getMeta() + ", getSchemas()=" + getSchemas() + "]";
+    }
+
+    @Override
+    @ValidCoreSchema(SCHEMA)
+    public Set<String> getSchemas() {
+        return super.getSchemas();
     }
 
     /**

--- a/src/main/java/org/osiam/resources/validation/CoreSchemaValidator.java
+++ b/src/main/java/org/osiam/resources/validation/CoreSchemaValidator.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.resources.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class CoreSchemaValidator implements ConstraintValidator<ValidCoreSchema, Set<String>> {
+
+    private String coreSchema;
+
+    @Override
+    public void initialize(ValidCoreSchema constraintAnnotation) {
+        this.coreSchema = constraintAnnotation.value();
+    }
+
+    @Override
+    public boolean isValid(Set<String> value, ConstraintValidatorContext context) {
+        return value == null || value.contains(coreSchema);
+    }
+}

--- a/src/main/java/org/osiam/resources/validation/ValidCoreSchema.java
+++ b/src/main/java/org/osiam/resources/validation/ValidCoreSchema.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.resources.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CoreSchemaValidator.class)
+@Documented
+@Repeatable(ValidCoreSchemas.class)
+public @interface ValidCoreSchema {
+    String message() default "Invalid core schema";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String value();
+}

--- a/src/main/java/org/osiam/resources/validation/ValidCoreSchemas.java
+++ b/src/main/java/org/osiam/resources/validation/ValidCoreSchemas.java
@@ -1,0 +1,38 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.resources.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCoreSchemas {
+
+    ValidCoreSchema[] value();
+}

--- a/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
@@ -93,6 +93,18 @@ class GroupControllerSpec extends Specification {
                 .andExpect(jsonPath('$.status').value('400'))
     }
 
+    def 'Creating a Group with invalid Schema raises a 400 BAD REQUEST'() {
+        when:
+        def response = mockMvc.perform(post('/Groups')
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"schemas": ["invalid schema"], "displayName": "Test Group"}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.detail').value('Invalid core schema'))
+                .andExpect(jsonPath('$.status').value('400'))
+    }
+
     def 'Retrieving a group calls get on provisioning'() {
         when:
         def response = mockMvc.perform(get("/Groups/${uuid}")

--- a/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
@@ -109,6 +109,18 @@ class UserControllerSpec extends Specification {
                 .andExpect(jsonPath('$.status').value('400'))
     }
 
+    def 'Creating a User with invalid Schema raises a 400 BAD REQUEST'() {
+        when:
+        def response = mockMvc.perform(post('/Users')
+                .contentType(MediaType.APPLICATION_JSON)
+                .content('{"schemas": ["invalid schema"], "userName": "Test User"}'))
+
+        then:
+        response.andExpect(status().isBadRequest())
+                .andExpect(jsonPath('$.detail').value('Invalid core schema'))
+                .andExpect(jsonPath('$.status').value('400'))
+    }
+
     def 'Retrieving a User calls get on provisioning'() {
         when:
         def response = mockMvc.perform(get("/Users/${uuid}")


### PR DESCRIPTION
The last refactoring of the validation removed the ability to validate
the schema of scim users and groups, i.e. It was possible to provide
users and groups with a wrong or no schema present.

This commit fixes it by providing a custom validator and annotation to
validate the provided schemas.

This closes #142
