### PR TITLE
Don't explicitly set sources in Servlet environment

### DIFF
--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -56,7 +56,7 @@ public class Osiam extends SpringBootServletInitializer {
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder applicationBuilder) {
         applicationBuilder.application().setDefaultProperties(DEFAULT_PROPERTIES);
-        return applicationBuilder.sources(Osiam.class);
+        return applicationBuilder;
     }
 
     @Bean


### PR DESCRIPTION
The current class inheriting `SpringBootServletInitializer` will be used
as application sources, if none is defined.
