### PR TITLE
Initialize home directory via command line

### DIFF
--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -13,6 +13,7 @@ Chapters:
 - [Download OSIAM](#download-osiam)
 - [The Home Directory](#the-home-directory)
 - [Configuration](#configuration)
+    - [Initialize the Home Directory from the Command Line](#initialize-the-home-directory-from-the-command-line)
 - [Starting OSIAM](#starting-osiam)
 - [Default setup](#default-setup)
 - [Customize setup](#customize-setup)
@@ -74,6 +75,20 @@ If no home directory is specified, `$HOME/.osiam` will be used.
 OSIAM initializes its home directory at startup, if the directory is empty.
 You should create a new directory for the home directory now, for instance `/var/lib/osiam`.
 We will refer to this directory as `OSIAM_HOME` from now on.
+
+### Initialize the Home Directory from the Command Line
+
+Sometimes it can be handy to initialize the home directory without actually starting OSIAM,
+especially when using an automated deployment process.
+You can do this by running the following command on the command line:
+
+```sh
+java -jar osiam.war initHome --osiam.home=/var/lib/osiam
+```
+
+**NOTE:** You can also use an environment variable `OSIAM_HOME` set to OSIAM's home directory.
+
+After that, you can change the configuration file and templates to your needs and then start OSIAM.
 
 ## Configuration
 

--- a/src/main/java/org/osiam/OsiamHome.java
+++ b/src/main/java/org/osiam/OsiamHome.java
@@ -57,7 +57,7 @@ public class OsiamHome {
             return;
         }
         checkState(Files.isWritable(osiamHomeDir), "'osiam.home' (%s) is not writable", osiamHomeDir);
-        logger.info("osiam.home ({}) is empty. Initializing it.", osiamHomeDir);
+        logger.info("Initializing osiam.home");
         Resource[] resources = new PathMatchingResourcePatternResolver().getResources("classpath:/home/**/*");
         for (Resource resource : resources) {
             // don't process directories

--- a/src/main/java/org/osiam/cli/InitHome.java
+++ b/src/main/java/org/osiam/cli/InitHome.java
@@ -1,0 +1,56 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.cli;
+
+import org.osiam.OsiamHome;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.config.ConfigFileApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+
+@Configuration
+public class InitHome {
+
+    @Value("${osiam.home}")
+    private String osiamHomeDir;
+
+    @PostConstruct
+    public void osiamHome() throws IOException {
+        new OsiamHome(osiamHomeDir);
+    }
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+
+    @Bean
+    public static ConfigFileApplicationListener configFileApplicationListener() {
+        return new ConfigFileApplicationListener();
+    }
+}


### PR DESCRIPTION
This adds a command to OSIAM, that allows one to initialize the home
directory without starting OSIAM.
The command parser is dead-simple and should be replaced by something
more sophisticated in the future, if we want to support more cli
commands.
The default command is `server` so one don't has to specify it
every time.
Depending on the command, the Application Context will be bootstrapped
with a different `@Configuration` class.
The `InitHome` class represents the simplest (but most sufficient)
configuration to initialize the home directory.
Use a customized `@ComponentScan` definition, to prevent loading the
`InitHome` bean during normal server startup.
