### PR TITLE
Remove auth-server client from merged server

### DIFF
--- a/src/main/java/db/migration/mysql/V2__migrations_from_2_5.java
+++ b/src/main/java/db/migration/mysql/V2__migrations_from_2_5.java
@@ -23,5 +23,5 @@
  */
 package db.migration.mysql;
 
-public class V2__replace_old_scopes extends db.migration.V2__replace_old_scopes {
+public class V2__migrations_from_2_5 extends db.migration.V2__migrations_from_2_5 {
 }

--- a/src/main/java/db/migration/postgresql/V2__migrations_from_2_5.java
+++ b/src/main/java/db/migration/postgresql/V2__migrations_from_2_5.java
@@ -23,5 +23,5 @@
  */
 package db.migration.postgresql;
 
-public class V2__replace_old_scopes extends db.migration.V2__replace_old_scopes {
+public class V2__migrations_from_2_5 extends db.migration.V2__migrations_from_2_5 {
 }


### PR DESCRIPTION
Rename the migration class, because from now on it's responsibility is
not only dealing with the scopes, but also to do all data migrations
from 2.5 to 3.0.

Resolves #49
