### PR TITLE
Always return the `id` attribute

### DIFF
--- a/src/main/java/org/osiam/resources/controller/GroupController.java
+++ b/src/main/java/org/osiam/resources/controller/GroupController.java
@@ -143,6 +143,7 @@ public class GroupController {
             );
         }
         result.add("schemas");
+        result.add("id");
         return result;
     }
 }

--- a/src/main/java/org/osiam/resources/controller/UserController.java
+++ b/src/main/java/org/osiam/resources/controller/UserController.java
@@ -155,7 +155,6 @@ public class UserController {
         return new ResponseEntity<>(group, headers, status);
     }
 
-
     private Set<String> extractAttributes(String attributesParameter) {
         Set<String> result = new HashSet<>();
         if (!Strings.isNullOrEmpty(attributesParameter)) {
@@ -167,6 +166,7 @@ public class UserController {
             );
         }
         result.add("schemas");
+        result.add("id");
         return result;
     }
 }

--- a/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
@@ -200,4 +200,20 @@ class GroupControllerSpec extends Specification {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
     }
 
+    def 'id is always returned'() {
+        given:
+        def randomUuid = UUID.randomUUID().toString()
+        def group = new Group.Builder("irrelevant")
+                .setId(randomUuid)
+                .build()
+        scimGroupProvisioning.search(_, _, _, _, _) >> new SCIMSearchResult<Group>([group], 1, 100, 1)
+
+        when:
+        def response = mockMvc.perform(get("/Groups")
+                .accept(MediaType.APPLICATION_JSON)
+                .param('attributes', 'displayName'))
+
+        then:
+        response.andExpect(jsonPath('$.Resources[0].id').value(randomUuid))
+    }
 }

--- a/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
@@ -37,8 +37,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 class UserControllerSpec extends Specification {
 
@@ -217,4 +224,20 @@ class UserControllerSpec extends Specification {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
     }
 
+    def 'id is always returned'() {
+        given:
+        def randomUuid = UUID.randomUUID().toString()
+        def user = new User.Builder("irrelevant")
+                .setId(randomUuid)
+                .build()
+        scimUserProvisioning.search(_, _, _, _, _) >> new SCIMSearchResult<User>([user], 1, 100, 1)
+
+        when:
+        def response = mockMvc.perform(get("/Users")
+                .accept(MediaType.APPLICATION_JSON)
+                .param('attributes', 'userName'))
+
+        then:
+        response.andExpect(jsonPath('$.Resources[0].id').value(randomUuid))
+    }
 }


### PR DESCRIPTION
The `id` attribute is defined with "a 'returned' characteristic of
always" [1].

[1] https://tools.ietf.org/html/rfc7643#section-3.1

Fixes #151
