### PR TITLE
Refactor processing of OSIAM's home directory

### DIFF
--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -51,14 +51,11 @@ import java.util.Map;
 public class Osiam extends SpringBootServletInitializer {
 
     private static final Map<String, Object> DEFAULT_PROPERTIES = ImmutableMap.<String, Object>of(
-            "osiam.home", System.getenv("HOME") + "/.osiam",
-            "spring.config.location", "classpath:/home/config/osiam.yaml,file:${osiam.home}/config/osiam.yaml"
+            "spring.config.location", "file:${osiam.home}/config/osiam.yaml"
     );
 
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication();
-        application.setDefaultProperties(DEFAULT_PROPERTIES);
-
         String command = extractCommand(args);
         if ("initHome".equals(command)) {
             application.setSources(Collections.<Object>singleton(InitHome.class));
@@ -66,7 +63,8 @@ public class Osiam extends SpringBootServletInitializer {
         } else {
             application.setSources(Collections.<Object>singleton(Osiam.class));
         }
-
+        application.addListeners(new OsiamHome());
+        application.setDefaultProperties(DEFAULT_PROPERTIES);
         application.run(args);
     }
 
@@ -84,6 +82,7 @@ public class Osiam extends SpringBootServletInitializer {
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder applicationBuilder) {
         applicationBuilder.application().setDefaultProperties(DEFAULT_PROPERTIES);
+        applicationBuilder.application().addListeners(new OsiamHome());
         return applicationBuilder;
     }
 

--- a/src/main/java/org/osiam/cli/InitHome.java
+++ b/src/main/java/org/osiam/cli/InitHome.java
@@ -23,34 +23,8 @@
  */
 package org.osiam.cli;
 
-import org.osiam.OsiamHome;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-
-import javax.annotation.PostConstruct;
-import java.io.IOException;
-
-@Configuration
 public class InitHome {
-
-    @Value("${osiam.home}")
-    private String osiamHomeDir;
-
-    @PostConstruct
-    public void osiamHome() throws IOException {
-        new OsiamHome(osiamHomeDir);
-    }
-
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-        return new PropertySourcesPlaceholderConfigurer();
-    }
-
-    @Bean
-    public static ConfigFileApplicationListener configFileApplicationListener() {
-        return new ConfigFileApplicationListener();
-    }
+    // Intentionally left empty. Home directory is automatically initialized by OsiamHome.
+    // Unfortunately, Spring Boot requires some class to be used as application source.
+    // As nothing has to be done, this empty class is used for that.
 }

--- a/src/main/java/org/osiam/configuration/WebApplicationConfig.java
+++ b/src/main/java/org/osiam/configuration/WebApplicationConfig.java
@@ -23,8 +23,7 @@
  */
 package org.osiam.configuration;
 
-import org.osiam.OsiamHome;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,13 +37,13 @@ import javax.servlet.Filter;
 @Configuration
 public class WebApplicationConfig extends WebMvcConfigurerAdapter {
 
-    @Autowired
-    private OsiamHome osiamHome;
+    @Value("${osiam.home}")
+    private String osiamHome;
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/css/**").addResourceLocations(osiamHome.getCssDirectory());
-        registry.addResourceHandler("/js/**").addResourceLocations(osiamHome.getJsDirectory());
+        registry.addResourceHandler("/css/**").addResourceLocations("file:" + osiamHome + "/css/");
+        registry.addResourceHandler("/js/**").addResourceLocations("file:" + osiamHome + "/js/");
     }
 
     @Bean
@@ -58,7 +57,7 @@ public class WebApplicationConfig extends WebMvcConfigurerAdapter {
     @Bean
     public MessageSource messageSource() {
         ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasename(osiamHome.getI18nDirectory() + "/login");
+        messageSource.setBasename("file:" + osiamHome + "/i18n/login");
         messageSource.setDefaultEncoding("utf-8");
         messageSource.setCacheSeconds(-1);
         return messageSource;


### PR DESCRIPTION
OSIAM will now load the configuration only from the YAML file in its
home directory. This is done by running the initialization as early as
possible via an `ApplicationListener`. Initialization will take place
when the environment is ready to use, but before external configuration
will be loaded by the `ConfigFileApplicationListener`.

OSIAM will now load the configuration only from the YAML file in its
home directory. This is done by running the initialization as early as
possible via an `ApplicationListener`. Initialization will take place
when the environment is ready to use, but before external configuration
will be loaded by the `ConfigFileApplicationListener`.

OSIAM will now load the configuration only from the YAML file in its
home directory. This is done by running the initialization as early as
possible via an `ApplicationListener`. Initialization will take place
when the environment is ready to use, but before external configuration
will be loaded by the `ConfigFileApplicationListener`.
