### PR TITLE
Initialize database via command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Support for H2 database has been added and a file-based one is the default
   configuration from now on. The usage scenarios are small installations,
   testing and development.
+- Migration and initialization of the database can be done from the command line
+  with the `migrateDb` command. See [Initialize the Database from the Command Line]
+  (docs/detailed-reference-installation.md#initialize-the-database-from-the-command-line).
+
 
 ### Changes
 

--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -14,6 +14,7 @@ Chapters:
 - [The Home Directory](#the-home-directory)
     - [Initialize the Home Directory from the Command Line](#initialize-the-home-directory-from-the-command-line)
 - [Configuration](#configuration)
+- [Initialize the Database from the Command Line](#initialize-the-database-from-the-command-line)
 - [Starting OSIAM](#starting-osiam)
 - [Default setup](#default-setup)
 - [Customize setup](#customize-setup)
@@ -87,6 +88,20 @@ It should be self-explanatory.
 You should at least change the database connection to point to a PostgreSQL or MySQL server,
 if you install OSIAM in a production environment.
 You have to restart OSIAM after making changes to this file.
+
+## Initialize the Database from the Command Line
+
+This is an optional step, but if you want to, you can now initialize the database before starting OSIAM.
+This might be helpful if you want to create additional data like clients or define extensions.
+Currently, the only way to define extensions is via direct database manipulation.
+The configuration should be fully created before you can run the command.
+To start the initialization run the following command on the command line:
+
+```sh
+java -jar osiam.war migrateDb --osiam.home=/var/lib/osiam
+```
+
+Of course, you can also use this command to migrate the database when updating OSIAM.
 
 ## Starting OSIAM
 

--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -26,6 +26,7 @@ package org.osiam;
 import com.google.common.collect.ImmutableMap;
 import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
 import org.osiam.cli.InitHome;
+import org.osiam.cli.MigrateDb;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -57,13 +58,18 @@ public class Osiam extends SpringBootServletInitializer {
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication();
         String command = extractCommand(args);
+        OsiamHome osiamHome = new OsiamHome();
         if ("initHome".equals(command)) {
             application.setSources(Collections.<Object>singleton(InitHome.class));
             application.setWebEnvironment(false);
+        } else if ("migrateDb".equals(command)) {
+            application.setSources(Collections.<Object>singleton(MigrateDb.class));
+            application.setWebEnvironment(false);
+            osiamHome.shouldInitializeHome(false);
         } else {
             application.setSources(Collections.<Object>singleton(Osiam.class));
         }
-        application.addListeners(new OsiamHome());
+        application.addListeners(osiamHome);
         application.setDefaultProperties(DEFAULT_PROPERTIES);
         application.run(args);
     }

--- a/src/main/java/org/osiam/OsiamHome.java
+++ b/src/main/java/org/osiam/OsiamHome.java
@@ -52,6 +52,7 @@ public class OsiamHome implements ApplicationListener<ApplicationEvent> {
     private static final Logger logger = LoggerFactory.getLogger(OsiamHome.class);
 
     private boolean hasInitializedHome = false;
+    private boolean shouldInitializeHome = true;
     private Path osiamHome;
 
     @Override
@@ -59,7 +60,9 @@ public class OsiamHome implements ApplicationListener<ApplicationEvent> {
         if (event instanceof ApplicationEnvironmentPreparedEvent) {
             ConfigurableEnvironment environment = ((ApplicationEnvironmentPreparedEvent) event).getEnvironment();
             configure(environment);
-            initialize();
+            if(shouldInitializeHome) {
+                initialize();
+            }
         } else if (event instanceof ApplicationPreparedEvent) {
             writeLogs();
         }
@@ -131,5 +134,9 @@ public class OsiamHome implements ApplicationListener<ApplicationEvent> {
         Path target = osiamHomeDir.resolve(pathUnderHome);
         Files.createDirectories(target.getParent());
         Files.copy(resource.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public void shouldInitializeHome(boolean shouldInitializeHome) {
+        this.shouldInitializeHome = shouldInitializeHome;
     }
 }

--- a/src/main/java/org/osiam/cli/MigrateDb.java
+++ b/src/main/java/org/osiam/cli/MigrateDb.java
@@ -1,0 +1,34 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.cli;
+
+import org.osiam.configuration.DatabaseConfiguration;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({DatabaseConfiguration.class, PropertyPlaceholderAutoConfiguration.class})
+public class MigrateDb {
+}


### PR DESCRIPTION
This adds a command to OSIAM, that allows one to initialize the home
directory without starting OSIAM. The home directory must already be
initialized and any configuration has to be done, before this command
can be used. This should prevent accidental faulty database migrations,
because the command fails, if no configuration can be found in the home
directory. Initialization will be switched off in `OsiamHome` to realize
this.

Resolves #167
