### PR TITLE
Respond with 500 Internal Server Error on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ OSIAM 2.5 to OSIAM 3.0, see the [migration notes](docs/migration.md).
 ### Fixes
 
 - Reply with 400 BAD REQUEST to invalid filters.
+- Reply with 500 INTERNAL SERVER ERROR, instead of 409 CONFLICT, on unexpected
+  errors.
 - Change URL of service provider configuration resource from
   `/ServiceProviderConfigs` to `/ServiceProviderConfig`.
 - Always return the `id` attribute, when searching for `User`s.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -299,6 +299,7 @@ new OsiamConnector.Builder()
 There have been some minor API changes, namely:
 
 - Invalid filters now get a reply of 400 BAD REQUEST.
+- Unexpected errors now reply with 500 INTERNAL SERVER ERROR instead of 409 CONFLICT.
 - The URL of the service provider configuration was changed from `/ServiceProviderConfigs` to `/ServiceProviderConfig`.
 
 Please update your applications accordingly.

--- a/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
+++ b/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
@@ -49,11 +49,18 @@ public class RestExceptionHandler {
     private static final Logger logger = LoggerFactory.getLogger(RestExceptionHandler.class);
 
     @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.CONFLICT)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ResponseBody
     public ErrorResponse defaultExceptionHandler(Exception ex) {
         logger.warn("An unexpected exception occurred", ex);
-        return produceErrorResponse("An unexpected error occurred", HttpStatus.CONFLICT);
+        return produceErrorResponse("An unexpected error occurred", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(OsiamException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ResponseBody
+    public ErrorResponse handleOsiamException(OsiamException e) {
+        return produceErrorResponse(e.getMessage(), HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler({IllegalArgumentException.class, InvalidFilterException.class, InvalidConstraintException.class,

--- a/src/test/groovy/org/osiam/resources/exception/RestExceptionHandlerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/exception/RestExceptionHandlerSpec.groovy
@@ -40,7 +40,7 @@ class RestExceptionHandlerSpec extends Specification {
         when:
         def result = exceptionHandler.defaultExceptionHandler(new NullPointerException(IRRELEVANT))
         then:
-        result.status == HttpStatus.CONFLICT as String
+        result.status == HttpStatus.INTERNAL_SERVER_ERROR as String
         result.detail == "An unexpected error occurred"
     }
 


### PR DESCRIPTION
If an unknown or unhandled exception occurs, OSIAM should respond with 500
Internal Server Error instead of 409 Conflict. Old behavior is retained for
`OsiamException`.

Blocked by #187
