### PR TITLE
Use H2 automatic mixed mode by default

### DIFF
--- a/src/main/resources/home/config/osiam.yaml
+++ b/src/main/resources/home/config/osiam.yaml
@@ -34,7 +34,7 @@ osiam:
     #
     vendor: h2
     driver: org.h2.Driver
-    url: jdbc:h2:${osiam.home}/data/osiam
+    url: jdbc:h2:${osiam.home}/data/osiam;AUTO_SERVER=TRUE
     username: sa
     password:
 


### PR DESCRIPTION
This will start an embedded H2 server on a random port. Only clients,
that have access to the database file, can connect to this server. This
has the advantage, that you can connect to the H2 database while OSIAM
is running, e.g. for backups. See [1] for details.

[1] http://www.h2database.com/html/features.html#auto_mixed_mode
