### PR TITLE
Make HTTP port configurable

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,4 @@ logging.level:
 spring.thymeleaf.prefix: file:${osiam.home}/templates/web/
 spring.jpa.hibernate.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy
 spring.jpa.hibernate.ddl-auto: none
+server.port: ${osiam.port:8080}

--- a/src/main/resources/home/config/osiam.yaml
+++ b/src/main/resources/home/config/osiam.yaml
@@ -24,6 +24,9 @@
 
 osiam:
 
+  # The port to listen on
+  port: 8080
+
   #
   # Database configuration
   #


### PR DESCRIPTION
The configuration property is called `osiam.port`, because of the
decision to wrap all Spring Boot properties [1]. It is bound to the
actual Spring Boot property by using the same technique as described in
"Use ‘short’ command line arguments" [2] in the Spring Boot manual.

[1] osiam#35
[2] https://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-use-short-command-line-arguments
