### PR TITLE
Make log level configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ OSIAM 2.5 to OSIAM 3.0, see the [migration notes](docs/migration.md).
   (docs/detailed-reference-installation.md#initialize-the-database-from-the-command-line).
 - Connections via AJP can be used now. This is disabled by default. See
   [Enable AJP support](docs/detailed-reference-installation.md#enable-ajp-support).
+- Set the logging level with the configuration property `osiam.logging.level`.
 
 ### Changes
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ logging.level:
   # Default log level is ERROR
   '': ERROR
   org.springframework: WARN
-  org.osiam: INFO
+  org.osiam: ${osiam.logging.level:INFO}
 
 spring.thymeleaf.prefix: file:${osiam.home}/templates/web/
 spring.jpa.hibernate.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy

--- a/src/main/resources/home/config/osiam.yaml
+++ b/src/main/resources/home/config/osiam.yaml
@@ -63,6 +63,13 @@ osiam:
     #connection-timeout-ms: 30000
 
   #
+  # Logging configuration
+  #
+  logging:
+    # Log level severity. Can be one of ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF
+    level: INFO
+
+  #
   # LDAP configuration
   #
   ldap:


### PR DESCRIPTION
The configuration property is called `osiam.logging.level`, because of
the decision to wrap all Spring Boot properties [1]. It also creates a
new namespace, which leaves enough space for future extensions. The
property is bound to the actual Spring Boot property by using the same
technique as described in "Use ‘short’ command line arguments" [2] in
the Spring Boot manual.

[1] osiam#35
[2] https://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-use-short-command-line-arguments
