### PR TITLE
Simplify command line parser

### DIFF
--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -39,6 +39,7 @@ import org.springframework.security.authentication.encoding.ShaPasswordEncoder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -75,14 +76,12 @@ public class Osiam extends SpringBootServletInitializer {
     }
 
     private static String extractCommand(String[] arguments) {
-        for (String argument : arguments) {
-            for (String splitArgument : argument.trim().split("\\s")) {
-                if (!splitArgument.trim().startsWith("--") && !splitArgument.trim().startsWith("-")) {
-                    return splitArgument.trim();
-                }
-            }
-        }
-        return "server";
+        return Arrays.stream(arguments)
+                .map(String::trim)
+                .filter(argument -> !argument.startsWith("-"))
+                .filter(argument -> !argument.startsWith("--"))
+                .findFirst()
+                .orElse("server");
     }
 
     @Override


### PR DESCRIPTION
The former version was a workaround, so one could use the Spring Boot
Maven plugin, because it only ever passes one argument to the
application, e.g. `initHome --osiam.home=...`. Since Spring Boot 1.3
this workaround doesn't apply anymore, so it can be removed. It wasn't
even safe, because it could fail on some edge cases.

Use a Java 8 stream in the hope that it's easier to comprehend.
