### PR TITLE
Make extensions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ OSIAM 2.5 to OSIAM 3.0, see the [migration notes](docs/migration.md).
 - Migration and initialization of the database can be done from the command line
   with the `migrateDb` command. See [Initialize the Database from the Command Line]
   (docs/detailed-reference-installation.md#initialize-the-database-from-the-command-line).
+- Configure SCIM extensions in the configuration file. See
+  [Configuring SCIM Extension](docs/detailed-reference-installation.md#configuring-scim-extension).
 - Connections via AJP can be used now. This is disabled by default. See
   [Enable AJP support](docs/detailed-reference-installation.md#enable-ajp-support).
 - Set the logging level with the configuration property `osiam.logging.level`.

--- a/src/main/java/org/osiam/scim/extension/ExtensionsConfiguration.java
+++ b/src/main/java/org/osiam/scim/extension/ExtensionsConfiguration.java
@@ -1,0 +1,139 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.scim.extension;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.osiam.resources.scim.ExtensionFieldType;
+import org.osiam.storage.ExtensionRepository;
+import org.osiam.storage.entities.ExtensionEntity;
+import org.osiam.storage.entities.ExtensionFieldEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toSet;
+
+@Component
+@ConfigurationProperties("osiam.scim")
+public class ExtensionsConfiguration {
+
+    private final ExtensionRepository extensionRepository;
+    private final List<Extension> extensions = new ArrayList<>();
+
+    @Autowired
+    public ExtensionsConfiguration(ExtensionRepository extensionRepository) {
+        this.extensionRepository = extensionRepository;
+    }
+
+    @PostConstruct
+    public void createExtensions() {
+        extensions.stream()
+                .filter(extension -> !extensionRepository.existsByUrnIgnoreCase(extension.getUrn()))
+                .map(Extension::toEntity)
+                .forEach(extensionRepository::saveAndFlush);
+    }
+
+    @Valid
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
+
+    public static class Extension {
+
+        @NotEmpty(message = "No URN defined for extension")
+        private String urn;
+
+        @NotEmpty(message = "No fields defined for extension")
+        @Valid
+        private final List<Field> fields = new ArrayList<>();
+
+        public ExtensionEntity toEntity(){
+            ExtensionEntity entity = new ExtensionEntity();
+            entity.setUrn(urn);
+            entity.setFields(fields.stream().map(Field::toEntity).collect(toSet()));
+            return entity;
+        }
+
+        public String getUrn() {
+            return urn;
+        }
+
+        public void setUrn(String urn) {
+            this.urn = urn;
+        }
+
+        public List<Field> getFields() {
+            return fields;
+        }
+    }
+
+    public static class Field {
+
+        @NotEmpty(message = "No name defined for field")
+        private String name;
+
+        @NotNull(message = "No type defined for field")
+        private ExtensionFieldType type;
+
+        private boolean required;
+
+        public ExtensionFieldEntity toEntity(){
+            ExtensionFieldEntity entity = new ExtensionFieldEntity();
+            entity.setName(name);
+            entity.setType(type);
+            entity.setRequired(required);
+            return entity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getType() {
+            return type != null ? type.toString() : null;
+        }
+
+        public void setType(String type) {
+            this.type = ExtensionFieldType.valueOf(type.toUpperCase());
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
+        }
+    }
+}

--- a/src/main/resources/home/config/osiam.yaml
+++ b/src/main/resources/home/config/osiam.yaml
@@ -66,6 +66,25 @@ osiam:
     #connection-timeout-ms: 30000
 
   #
+  # SCIM Extensions
+  #
+  scim:
+    extensions:
+      #- urn: exampleExtension1
+      #  fields:
+      #    - name: requiredStringField
+      #      # Case-insensitive, so can also be 'string' or 'String'
+      #      type: STRING
+      #      # Optional, by default fields are not required to have a value
+      #      required: yes
+      #    - name: integerField
+      #      type: INTEGER
+      #- urn: exampleExtension2
+      #  fields:
+      #    - name: booleanField
+      #      type: BOOLEAN
+
+  #
   # Logging configuration
   #
   logging:

--- a/src/test/groovy/org/osiam/scim/extension/ExtensionsConfigurationSpec.groovy
+++ b/src/test/groovy/org/osiam/scim/extension/ExtensionsConfigurationSpec.groovy
@@ -1,0 +1,84 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2013-2016 tarent solutions GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.osiam.scim.extension
+
+import org.osiam.Osiam
+import org.osiam.resources.scim.ExtensionFieldType
+import org.osiam.storage.ExtensionRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.EnvironmentTestUtils
+import org.springframework.boot.test.SpringApplicationConfiguration
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.ConfigurableEnvironment
+import spock.lang.Specification
+
+class ExtensionsConfigurationSpec extends Specification {
+
+    def extensionRepository = Mock(ExtensionRepository)
+    def ExtensionsConfiguration extensionsConfig = new ExtensionsConfiguration(extensionRepository)
+
+    def 'Creates the configured extension, if it does not exist'() {
+        given:
+        def extensionToCreate = new ExtensionsConfiguration.Extension()
+        extensionToCreate.urn = 'urn'
+        def fieldToCreate = new ExtensionsConfiguration.Field()
+        fieldToCreate.name = 'name'
+        fieldToCreate.type = 'string'
+        fieldToCreate.required = true
+        extensionToCreate.getFields().add(fieldToCreate)
+        extensionsConfig.extensions.add(extensionToCreate)
+        extensionRepository.existsByUrnIgnoreCase('urn') >> false
+
+        when:
+        extensionsConfig.createExtensions()
+
+        then:
+        1 * extensionRepository.saveAndFlush({ extension ->
+            extension.urn == 'urn'
+            def field = extension.fields.iterator().next()
+            field.name == 'name'
+            field.required == true
+            field.type == ExtensionFieldType.STRING
+        })
+    }
+
+    def 'Does not do anything, if the configured extension already exists'() {
+        given:
+        def extensionToCreate = new ExtensionsConfiguration.Extension()
+        extensionToCreate.urn = 'urn'
+        def fieldToCreate = new ExtensionsConfiguration.Field()
+        fieldToCreate.name = 'name'
+        fieldToCreate.type = 'string'
+        extensionToCreate.getFields().add(fieldToCreate)
+        extensionsConfig.extensions.add(extensionToCreate)
+        extensionRepository.existsByUrnIgnoreCase('urn') >> true
+
+        when:
+        extensionsConfig.createExtensions()
+
+        then:
+        0 * extensionRepository.saveAndFlush(_)
+    }
+}


### PR DESCRIPTION
Read extensions from `osiam.yaml` and create them on start up. If the
extension already exists, don't create it. Add new value classes for
extension and extension field, because the `ExtensionEntity` stores the
fields as `Set` and Spring is unable to bind a YAML list to a `Set`.
This is due to lists are ordered, but sets not. Use Bean validation to
validate the configured extensions, which keeps the code simpler.

Closes #186
Closes #105
