### PR TITLE
Fix JPA model generation error in IntelliJ IDEA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jpamodelgen</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.6</version>
@@ -573,13 +579,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.hibernate</groupId>
-                        <artifactId>hibernate-jpamodelgen</artifactId>
-                        <version>4.3.10.Final</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
IDEA only picks up the Jar, if it is on the classpath. Use an optional
dependency in the POM to realize this. The version is already defined by
Spring Boot's parent POM.
