### PR TITLE
Cleanup exception handling in provisioning services

### DIFF
--- a/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
+++ b/src/main/java/org/osiam/resources/provisioning/SCIMGroupProvisioning.java
@@ -26,7 +26,6 @@ package org.osiam.resources.provisioning;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.osiam.resources.converter.GroupConverter;
 import org.osiam.resources.exception.ResourceExistsException;
-import org.osiam.resources.exception.ResourceNotFoundException;
 import org.osiam.resources.provisioning.update.GroupUpdater;
 import org.osiam.resources.scim.Group;
 import org.osiam.resources.scim.SCIMSearchResult;
@@ -34,21 +33,15 @@ import org.osiam.storage.dao.GroupDao;
 import org.osiam.storage.dao.SearchResult;
 import org.osiam.storage.entities.GroupEntity;
 import org.osiam.storage.query.QueryFilterParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.NoResultException;
-import javax.persistence.PersistenceException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 @Service
 public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
-
-    private static final Logger logger = LoggerFactory.getLogger(SCIMGroupProvisioning.class);
 
     private final GroupConverter groupConverter;
     private final GroupDao groupDao;
@@ -121,17 +114,7 @@ public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
 
     @Override
     public Group getById(String id) {
-        try {
-            return groupConverter.toScim(groupDao.getById(id));
-        } catch (NoResultException nre) {
-            logger.info(nre.getMessage(), nre);
-
-            throw new ResourceNotFoundException(String.format("Group with id '%s' not found", id), nre);
-        } catch (PersistenceException pe) {
-            logger.warn(pe.getMessage(), pe);
-
-            throw new ResourceNotFoundException(String.format("Group with id '%s' not found", id), pe);
-        }
+        return groupConverter.toScim(groupDao.getById(id));
     }
 
     @Override
@@ -160,10 +143,6 @@ public class SCIMGroupProvisioning implements SCIMProvisioning<Group> {
 
     @Override
     public void delete(String id) {
-        try {
-            groupDao.delete(id);
-        } catch (NoResultException nre) {
-            throw new ResourceNotFoundException(String.format("Group with id '%s' not found", id), nre);
-        }
+        groupDao.delete(id);
     }
 }

--- a/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/SCIMGroupProvisioningBeanSpec.groovy
@@ -156,7 +156,7 @@ class SCIMGroupProvisioningBeanSpec extends Specification {
         scimGroupProvisioning.delete(groupUuid)
 
         then:
-        1 * groupDao.delete(groupUuid) >> { throw new NoResultException() }
+        1 * groupDao.delete(groupUuid) >> { throw new ResourceNotFoundException("Group with id '${groupUuid}' not found") }
         def rnfe = thrown(ResourceNotFoundException)
 
         rnfe.getMessage().with {

--- a/src/test/groovy/org/osiam/resources/provisioning/UserDeleteSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/provisioning/UserDeleteSpec.groovy
@@ -48,7 +48,7 @@ class UserDeleteSpec extends Specification {
         scimUserProvisioning.delete(uuidAsString)
 
         then:
-        1 * userDao.delete(uuidAsString) >> { throw new NoResultException() }
+        1 * userDao.delete(uuidAsString) >> { throw new ResourceNotFoundException("User with id '${uuidAsString}' not found") }
         def rnfe = thrown(ResourceNotFoundException)
 
         rnfe.getMessage().with {


### PR DESCRIPTION
The removed `try-catch` blocks are handling exceptions, that will never
bubble up to them. They also hide sever errors of the persistence layer,
by handling them as "resource not found" errors.
