### PR TITLE
Enable attribute filtering on all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ OSIAM 2.5 to OSIAM 3.0, see the [migration notes](docs/migration.md).
 - Connections via AJP can be used now. This is disabled by default. See
   [Enable AJP support](docs/detailed-reference-installation.md#enable-ajp-support).
 - Set the logging level with the configuration property `osiam.logging.level`.
+- It's possible to filter all returned resources returned by request to the `/Users`
+  and `/Groups` URLs, including searches, by passing a comma separated list of
+  attributes to be included in the returned resources.
 
 ### Changes
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -18,14 +18,14 @@
     - [Service provider configuration](#service-provider-configuration)
     - [Search](#search)
         - [Search filtering including logical operators](#search-filtering-including-logical-operators)
-        - [Limiting the output to predefined attributes] (#limiting-the-output-to-predefined-attributes)
+        - [Limiting the output to predefined attributes](#limiting-the-output-to-predefined-attributes)
         - [Sorting](#sorting)
         - [Paging](#paging)
     - [User management](#user-management)
-        - [Get a single User] (#get-a-single-user)
+        - [Get a single User](#get-a-single-user)
         - [Get the User of the current accessToken](#get-the-user-of-the-current-accesstoken)
-        - [Create a new User] (#create-a-new-user)
-        - [Replace an existing User] (#replace-an-existing-user)
+        - [Create a new User](#create-a-new-user)
+        - [Replace an existing User](#replace-an-existing-user)
         - [Update a User](#update-a-user)
         - [Get the Authenticated User](#get-the-authenticated-user)
         - [Delete a User](#delete-a-user)
@@ -351,8 +351,8 @@ tokens are bound to a client or a user and need specific scopes, which are
 * xmlDataFormat is not supported
 
 ### OSIAM's Known Limitations
-* the [etag](http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.11) is
-not supported yet, but it is already in OSIAMs backlog
+* [etag](http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.11) for resource
+versioning is not supported yet, but it is already in OSIAMs backlog
 
 ### Unsupported Interfaces
 * SCIM bulk actions: Is not yet implemented, but it is on the roadmap
@@ -370,7 +370,7 @@ http://OSIAM_HOST:8080/osiam/ServiceProviderConfig
 ```
 
 ### Search
-OSIAM supports search on both SCIM resource types, user and group.
+OSIAM supports search for both SCIM resource types, user and group.
 * Users: 
 ```
 http://OSIAM_HOST:8080/osiam/Users
@@ -551,12 +551,11 @@ http://OSIAM_HOST:8080/osiam/Users?access_token=$YOUR_ACCESSTOKEN&count=5&startI
 
 ### User management
 
-This section will describe the handling of user with OSIAM.
+This section describes the handling of user with OSIAM.
 
-#### Get a single User
+#### Retrieving a single User
 
-To get a single user you need to send a GET request to the URL providing the
-user's ID
+Retrieving a single user is done by sending a GET request to the `/Users` URL providing the users id
 
 ```http
 http://OSIAM_HOST:8080/osiam/Users/ID
@@ -571,6 +570,16 @@ curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Au
 See [SCIMv2 specification]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.2.1) for further
 details.
+
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X GET http://localhost:8080/osiam/Users/$ID?attributes=userName,meta.created
+```
 
 #### Create a new User
 
@@ -593,6 +602,16 @@ See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.1) for further
 details.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam/Users?attributes=userName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"externalId":"external_id","userName":"arthur","password":"dent"}'
+```
+
 #### Replace an existing User
 To replace an existing user you need to send the user input as json via put to
 the url
@@ -612,6 +631,16 @@ See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.1) for further
 details.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam/Users?attributes=userName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"externalId":"ne_externalId","userName":"arthur","password":"dent"}'
+```
+
 #### Update a User
 To update an existing user you need to send the fields you which to update or
 delete as json via patch to the url
@@ -620,7 +649,7 @@ delete as json via patch to the url
 http://OSIAM_HOST:8080/osiam/Users/$ID
 ```
 
-the response will be the updated user in json format.
+the response is the updated user in JSON format.
 
 e.g.:
 ```sh
@@ -654,9 +683,20 @@ curl -i -H "Accept: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOK
 
 The response is the json representation of the user currently authenticated with the provided access token.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X GET http://localhost:8080/osiam/Me?attributes=displayName,meta.created
+```
+
+
 ### Group management
 
-This section will describe the handling of user in the osiam context.
+This section describes the handling of user in the osiam context.
 
 #### Get a single Group
 
@@ -678,6 +718,16 @@ See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.2.1) for further
 details.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X GET http://localhost:8080/osiam/Groups/$ID?attributes=displayName,meta.created
+```
+
 #### Create a new Group
 To create a new group you need to send the group input as json via post to the
 url
@@ -698,6 +748,16 @@ See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.1) for further
 details.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X POST http://localhost:8080/osiam/Groups?attributes=deisplayName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"adminsGroup"}'
+```
+
 #### Replace an existing Group
 To replace a group you need to send the group input as json via put to the url
 
@@ -716,6 +776,15 @@ See [scim 2 rest spec]
 (http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.1) for further
 details.
 
+##### Filtering the output with predefined attributes
+
+It is possible to filter the returned resource by a list of
+attributes. To define more than one separate them with comma using the
+`attributes` parameter.
+
+```sh
+curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/osiam/Groups?attributes=deisplayName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"newDisplayName"}'
+```
 #### Update a Group
 To update a group you need to send the fields you which to update oder delete
 as json via patch to the url

--- a/src/main/java/org/osiam/resources/controller/MeController.java
+++ b/src/main/java/org/osiam/resources/controller/MeController.java
@@ -28,17 +28,15 @@ import org.osiam.resources.exception.InvalidTokenException;
 import org.osiam.resources.provisioning.SCIMUserProvisioning;
 import org.osiam.resources.scim.User;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJacksonValue;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * This Controller is used for getting information about the user who initialised the access_token.
@@ -59,8 +57,10 @@ public class MeController extends ResourceController<User> {
     }
 
     @RequestMapping(method = RequestMethod.GET)
-    public ResponseEntity<User> getCurrentUser(@RequestHeader("Authorization") String tokenHeader,
-                                               UriComponentsBuilder builder) {
+    public MappingJacksonValue getCurrentUser(@RequestHeader("Authorization") String tokenHeader,
+                                              @RequestParam(required = false) String attributes,
+                                              HttpServletResponse response,
+                                              UriComponentsBuilder builder) {
 
         if (Strings.isNullOrEmpty(tokenHeader)) {
             throw new IllegalArgumentException("No access token provided!"); // This should never happen!
@@ -82,6 +82,8 @@ public class MeController extends ResourceController<User> {
         } else {
             throw new IllegalArgumentException("User not authenticated.");
         }
-        return buildResponseWithLocation(user, builder, HttpStatus.OK);
+
+        response.setHeader("Location", buildLocation(user, builder).toString());
+        return buildResponse(user, attributes);
     }
 }

--- a/src/main/java/org/osiam/resources/controller/ResourceController.java
+++ b/src/main/java/org/osiam/resources/controller/ResourceController.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ResourceController<T extends Resource> {
+public abstract class ResourceController<T extends Resource> {
 
     protected ResponseEntity<T> buildResponseWithLocation(T resource,
                                                           UriComponentsBuilder builder,


### PR DESCRIPTION
This pull request enables the filtering of resources returned to all requests by attributes with the request parameter `attributes` and the attributes you want to be returned.
