### PR TITLE
Assign controllers to the right exception handlers

### DIFF
--- a/src/main/java/org/osiam/auth/exception/WebExceptionHandler.java
+++ b/src/main/java/org/osiam/auth/exception/WebExceptionHandler.java
@@ -23,6 +23,8 @@
  */
 package org.osiam.auth.exception;
 
+import org.osiam.security.controller.AccessConfirmationController;
+import org.osiam.security.controller.LoginController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -30,7 +32,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 
-@ControllerAdvice("org.osiam.security.controller")
+@ControllerAdvice(
+        assignableTypes = {LoginController.class, AccessConfirmationController.class}
+)
 public class WebExceptionHandler extends SimpleMappingExceptionResolver {
 
     private static final Logger logger = LoggerFactory.getLogger(WebExceptionHandler.class.getName());

--- a/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
+++ b/src/main/java/org/osiam/resources/exception/RestExceptionHandler.java
@@ -29,6 +29,7 @@ import org.osiam.auth.exception.ClientAlreadyExistsException;
 import org.osiam.auth.exception.ClientNotFoundException;
 import org.osiam.auth.exception.JsonErrorResult;
 import org.osiam.resources.scim.ErrorResponse;
+import org.osiam.security.controller.TokenController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -39,11 +40,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ControllerAdvice({
-        "org.osiam.auth.oauth_client",
-        "org.osiam.metrics.controller",
-        "org.osiam.resources.controller"
-})
+@ControllerAdvice(
+        basePackages = {"org.osiam.auth.oauth_client", "org.osiam.metrics.controller", "org.osiam.resources.controller" },
+        assignableTypes = TokenController.class
+)
 public class RestExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(RestExceptionHandler.class);


### PR DESCRIPTION
`LoginController` and `AccessConfirmationController` are completely
serving the web interfaces, while `TokenController` is part of the REST
API. The package `org.osiam.security.controller` only contains these 3
controllers.

Resolves #48
