### PR TITLE
Publish latest snapshot as `osiam-latest` also to bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ with your application. Read the
 
 ## Snapshots
 
-To use the latest snapshot of OSIAM just download it from the oss jfrog
-repository: https://oss.jfrog.org/artifactory/repo/org/osiam/osiam
+To use the latest snapshot of OSIAM just download it from Bintray:
+https://dl.bintray.com/osiam/downloads/osiam/latest/osiam-latest.war
+([GPG Signature](https://dl.bintray.com/osiam/downloads/osiam/latest/osiam-latest.war.asc))
 
 ## Issue Tracker
 

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,7 @@ deployment:
    commands:
      - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
      - mvn deploy -s settings.xml -DskipTests
+     - curl -T target/osiam.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:osiam" -H "X-Bintray-Version:latest" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/osiam/latest/osiam-latest.war
      - curl -X POST https://circleci.com/api/v1/project/osiam/connector4java-integration-tests/tree/master?circle-token=$CIRCLE_TOKEN
      - >
       curl -H "Content-Type: application/json" --data '{"source_type": "Branch", "source_name": "master"}' -X POST https://registry.hub.docker.com/u/osiamorg/osiam/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/


### PR DESCRIPTION
Because it is not possible to link to the changed OSIAM snapshot
maven artifacts in the oss jfrog maven repository, this commit
changes that the latest OSIAM snapshot is also available under
a static download link:
https://dl.bintray.com/osiam/downloads/osiam/latest/osiam-latest.war
