### PR TITLE
Only deploy the WAR file without building again

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,11 @@ deployment:
     branch: master
     commands:
       - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
-      - mvn deploy -s settings.xml -DskipTests
+      - >
+        mvn deploy:deploy-file
+          -DrepositoryId=snapshots
+          -Durl=https://oss.jfrog.org/artifactory/oss-snapshot-local
+          -s settings.xml
       - curl -T target/osiam.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:osiam" -H "X-Bintray-Version:latest" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/osiam/latest/osiam-latest.war
       - curl -X POST https://circleci.com/api/v1/project/osiam/connector4java-integration-tests/tree/master?circle-token=$CIRCLE_TOKEN
       - >
@@ -36,5 +40,9 @@ deployment:
     owner: osiam
     commands:
       - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
-      - mvn deploy -s settings.xml -DskipTests
+      - >
+        mvn deploy:deploy-file
+          -DrepositoryId=releases
+          -Durl=https://api.bintray.com/maven/osiam/OSIAM/org.osiam:osiam/;publish=1
+          -s settings.xml
       - curl -T target/osiam.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:osiam" -H "X-Bintray-Version:${CIRCLE_TAG}" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/osiam/${CIRCLE_TAG}/osiam-${CIRCLE_TAG}.war

--- a/pom.xml
+++ b/pom.xml
@@ -80,19 +80,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <distributionManagement>
-        <repository>
-            <id>releases</id>
-            <name>osiam-releases</name>
-            <url>https://api.bintray.com/maven/osiam/OSIAM/org.osiam:osiam/;publish=1</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>osiam-snapshots</name>
-            <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
@@ -295,7 +282,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <finalName>osiam</finalName>
+                    <finalName>${project.artifactId}</finalName>
                     <executable>true</executable>
                     <folders>
                         <folder>src/main/deploy</folder>
@@ -446,18 +433,12 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.0</version>
-                <inherited>true</inherited>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <file>${build.directory}/${project.artifactId}.war</file>
+                    <pomFile>pom.xml</pomFile>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Remove distribution management, because the repo id and URL is now
contained in the `circle.yml`. Remove sources plug-in, as we don't
distribute the sources on that way.
