### PR TITLE
Remove the ability to update resources via PATCH

### DIFF
--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -646,24 +646,6 @@ attributes. To define more than one separate them with comma using the
 curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/Users?attributes=userName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"externalId":"ne_externalId","userName":"arthur","password":"dent"}'
 ```
 
-#### Update a User
-To update an existing user you need to send the fields you which to update or
-delete as json via patch to the url
-
-```http
-http://OSIAM_HOST:8080/Users/$ID
-```
-
-the response is the updated user in JSON format.
-
-e.g.:
-```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/Users/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"], "externalId":"new_external_id"}'
-```
-See [scim 2 rest spec]
-(http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.2) for further
-details.
-
 #### Delete a User
 To delete an existing user you need to call the url via delete
 
@@ -790,24 +772,6 @@ attributes. To define more than one separate them with comma using the
 ```sh
 curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PUT http://localhost:8080/Groups?attributes=deisplayName,meta.created -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"newDisplayName"}'
 ```
-#### Update a Group
-To update a group you need to send the fields you which to update oder delete
-as json via patch to the url
-
-```http
-http://OSIAM_HOST:8080/Groups/$ID
-```
-
-the response will be the updated group in json format.
-
-e.g.:
-
-```sh
-curl -i -H "Accept: application/json" -H "Content-type: application/json" -H "Authorization: Bearer $YOUR_ACCESS_TOKEN" -X PATCH http://localhost:8080/Groups/$ID -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName":"adminsGroup"}'
-```
-See [scim 2 rest spec]
-(http://tools.ietf.org/html/draft-ietf-scim-api-02#section-3.3.2) for further
-details.
 
 #### Delete a Group
 To delete a group you need to call the url via delete

--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -304,7 +304,7 @@ You can check from the commandline whether OSIAM is started by using the followi
 
 Everything is fine when you see a JSON string as response that looks like this:
 
-    {"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"patch":{"supported":true},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
+    {"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"patch":{"supported":false},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
     
 ## Default setup
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -188,7 +188,7 @@ curl http://localhost:8080/osiam/ServiceProviderConfig
 If OSIAM is running correctly, you will get the following (or similar) response:
 
 ```json
-{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"patch":{"supported":true},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
+{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"patch":{"supported":false},"bulk":{"supported":false},"filter":{"supported":true,"maxResults":100},"changePassword":{"supported":false},"sort":{"supported":true},"etag":{"supported":false},"xmlDataFormat":{"supported":false},"authenticationSchemes":{"authenticationSchemes":[{"name":"Oauth2 Bearer","description":"OAuth2 Bearer access token is used for authorization.","specUrl":"http://tools.ietf.org/html/rfc6749","documentationUrl":"http://oauth.net/2/"}]}}
 ```
 
 ### Clean Up

--- a/src/main/java/org/osiam/resources/controller/GroupController.java
+++ b/src/main/java/org/osiam/resources/controller/GroupController.java
@@ -84,15 +84,6 @@ public class GroupController extends ResourceController<Group> {
         return buildResponseWithLocation(updatedGroup, builder, HttpStatus.OK, attributes);
     }
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH)
-    public ResponseEntity<MappingJacksonValue> update(@PathVariable final String id,
-                                                      @RequestBody Group group,
-                                                      UriComponentsBuilder builder)
-            throws IOException {
-        Group updatedGroup = scimGroupProvisioning.update(id, group);
-        return buildResponseWithLocation(updatedGroup, builder, HttpStatus.OK, ""); // we're going to remove patch soon anyways
-    }
-
     @RequestMapping(method = RequestMethod.GET)
     public MappingJacksonValue searchWithGet(@RequestParam Map<String, String> requestParameters) {
         return searchWithPost(requestParameters);

--- a/src/main/java/org/osiam/resources/controller/ServiceProviderConfigController.java
+++ b/src/main/java/org/osiam/resources/controller/ServiceProviderConfigController.java
@@ -45,7 +45,7 @@ public class ServiceProviderConfigController {
 
         public static final ServiceProviderConfig INSTANCE = new ServiceProviderConfig();
         public static final String SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
-        public final Supported patch = new Supported(true);
+        public final Supported patch = new Supported(false);
         public final Supported bulk = new BulkSupported(false);
         public final Supported filter = new FilterSupported(true, SCIMSearchResult.MAX_RESULTS);
         public final Supported changePassword = new Supported(false);

--- a/src/main/java/org/osiam/resources/controller/UserController.java
+++ b/src/main/java/org/osiam/resources/controller/UserController.java
@@ -89,16 +89,6 @@ public class UserController extends ResourceController<User> {
         return buildResponseWithLocation(createdUser, builder, HttpStatus.OK, attributes);
     }
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.PATCH)
-    public ResponseEntity<MappingJacksonValue> update(@PathVariable String id,
-                                                      @RequestBody User user,
-                                                      UriComponentsBuilder builder)
-            throws IOException {
-        User createdUser = scimUserProvisioning.update(id, user);
-        checkAndHandleDeactivation(id, user);
-        return buildResponseWithLocation(createdUser, builder, HttpStatus.OK, ""); // We're going to remove this soon
-    }
-
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.OK)
     public void delete(@PathVariable final String id) {

--- a/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/GroupControllerSpec.groovy
@@ -192,29 +192,6 @@ class GroupControllerSpec extends Specification {
                 .andExpect(jsonPath('$.status').value(HttpStatus.BAD_REQUEST.toString()))
     }
 
-    def 'Replacing a group using PATCH sets the location header as expected'() {
-        when:
-        def response = mockMvc.perform(patch("/Groups/${uuid}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(minimalGroup))
-
-        then:
-        1 * scimGroupProvisioning.update(uuid.toString(), _) >> responseGroup
-        response.andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(header().string('Location', "http://localhost/Groups/${uuid}"))
-                .andExpect(jsonPath('$.id').value(uuid as String)) // is nonsense because it's what we give in
-    }
-
-    def 'Replacing an invalid group using PATCH raises a 400 BAD REQUEST'() {
-        when:
-        def response = mockMvc.perform(put("/Groups/${uuid}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content('{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName": ""}}'))
-        then:
-        response.andExpect(status().isBadRequest())
-    }
-
     def 'Search parameters default to SCIM RFC values'() {
         when:
         def response = mockMvc.perform(get("/Groups")

--- a/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/ServiceProviderConfigSpec.groovy
@@ -38,7 +38,7 @@ class ServiceProviderConfigSpec extends Specification {
 
         then:
         config.schemas == schemas
-        config.patch.supported
+        !config.patch.supported
         !config.bulk.supported
         !config.bulk.maxOperations
         !config.bulk.maxPayloadSize

--- a/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/resources/controller/UserControllerSpec.groovy
@@ -205,29 +205,6 @@ class UserControllerSpec extends Specification {
                 .andExpect(jsonPath('$.status').value(HttpStatus.BAD_REQUEST.toString()))
     }
 
-    def 'Replacing a User using PATCH sets the location header as expected'() {
-        when:
-        def response = mockMvc.perform(patch("/Users/${uuid}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(minimalUser))
-
-        then:
-        1 * scimUserProvisioning.update(uuid.toString(), _) >> responseUser
-        response.andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(header().string('Location', "http://localhost/Users/${uuid}"))
-                .andExpect(jsonPath('$.id').value(uuid as String)) // is nonsense because it's what we give in
-    }
-
-    def 'Replacing an invalid User using PATCH raises a 400 BAD REQUEST'() {
-        when:
-        def response = mockMvc.perform(put("/Users/${uuid}")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content('{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],"userName": ""}}'))
-        then:
-        response.andExpect(status().isBadRequest())
-    }
-
     def 'Search parameters default to SCIM RFC values'() {
         when:
         def response = mockMvc.perform(get("/Users")


### PR DESCRIPTION
Only remove the REST endpoints in the controllers. Everything else will
be removed in a future update. This approach has been chosen, to hold
the deadline for OSIAM 3.0. Removing the residues of updates via PATCH
is already in progress and will come with OSIAM 3.1.

Resolves #21
