### PR TITLE
Update Spring Boot to version 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <version>2.4.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.7.RELEASE</version>
+        <version>1.4.1.RELEASE</version>
     </parent>
 
     <groupId>org.osiam</groupId>

--- a/src/main/java/org/osiam/Osiam.java
+++ b/src/main/java/org/osiam/Osiam.java
@@ -30,7 +30,7 @@ import org.osiam.cli.MigrateDb;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;

--- a/src/main/java/org/osiam/auth/exception/LdapAuthenticationProcessException.java
+++ b/src/main/java/org/osiam/auth/exception/LdapAuthenticationProcessException.java
@@ -26,7 +26,7 @@ package org.osiam.auth.exception;
 import org.springframework.security.core.*;
 
 public class LdapAuthenticationProcessException extends AuthenticationException {
-    
+
     public LdapAuthenticationProcessException(String s) {
         super(s);
     }

--- a/src/main/java/org/osiam/auth/login/internal/InternalAuthenticationProvider.java
+++ b/src/main/java/org/osiam/auth/login/internal/InternalAuthenticationProvider.java
@@ -27,7 +27,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.osiam.resources.exception.ResourceNotFoundException;
 import org.osiam.resources.provisioning.SCIMUserProvisioning;
-import org.osiam.resources.scim.Role;
 import org.osiam.resources.scim.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -46,7 +45,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;

--- a/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
+++ b/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
@@ -39,7 +39,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.util.Collection;
@@ -78,8 +77,7 @@ public class ClientEntity implements ClientDetails {
     private int refreshTokenValiditySeconds;
 
     @JsonProperty
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     @Column(nullable = false)
     private String redirectUri;
 

--- a/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
+++ b/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
@@ -128,7 +128,7 @@ public class ClientEntity implements ClientDetails {
     @Override
     @JsonIgnore
     public Map<String, Object> getAdditionalInformation() {
-        return Collections.singletonMap("validityInSeconds", (Object) validityInSeconds);
+        return Collections.singletonMap("validityInSeconds", validityInSeconds);
     }
 
     @Override

--- a/src/main/java/org/osiam/configuration/DatabaseConfiguration.java
+++ b/src/main/java/org/osiam/configuration/DatabaseConfiguration.java
@@ -25,8 +25,6 @@ package org.osiam.configuration;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.flywaydb.core.Flyway;
-import org.flywaydb.core.api.MigrationVersion;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,9 +49,6 @@ public class DatabaseConfiguration {
     @Value("${osiam.db.password}")
     private String databasePassword;
 
-    @Value("${osiam.db.vendor}")
-    private String databaseVendor;
-
     @Value("${osiam.db.maximum-pool-size:10}")
     private int maximumPoolSize;
 
@@ -72,16 +67,5 @@ public class DatabaseConfiguration {
         hikariConfig.setMaximumPoolSize(maximumPoolSize);
         hikariConfig.setConnectionTimeout(connectionTimeoutMs);
         return new HikariDataSource(hikariConfig);
-    }
-
-    @Bean
-    public Flyway flyway() {
-        Flyway flyway = new Flyway();
-        flyway.setDataSource(dataSource());
-        flyway.setLocations("db/migration/" + databaseVendor);
-        flyway.setBaselineOnMigrate(true);
-        flyway.setBaselineVersion(MigrationVersion.fromVersion("1"));
-        flyway.migrate();
-        return flyway;
     }
 }

--- a/src/main/java/org/osiam/storage/entities/AddressEntity.java
+++ b/src/main/java/org/osiam/storage/entities/AddressEntity.java
@@ -23,14 +23,13 @@
  */
 package org.osiam.storage.entities;
 
+import org.hibernate.annotations.Type;
+import org.osiam.resources.scim.Address;
+
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.Index;
-import javax.persistence.Lob;
 import javax.persistence.Table;
-
-import org.hibernate.annotations.Type;
-import org.osiam.resources.scim.Address;
 
 /**
  * Address Entity
@@ -55,8 +54,7 @@ public class AddressEntity extends BaseMultiValuedAttributeEntity {
     @Basic
     private Address.Type type; // @Basic is needed for JPA meta model generator
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     private String formatted;
 
     private String streetAddress;

--- a/src/main/java/org/osiam/storage/entities/BaseMultiValuedAttributeEntityWithValue.java
+++ b/src/main/java/org/osiam/storage/entities/BaseMultiValuedAttributeEntityWithValue.java
@@ -23,16 +23,14 @@
  */
 package org.osiam.storage.entities;
 
-import javax.persistence.Lob;
-import javax.persistence.MappedSuperclass;
-
 import org.hibernate.annotations.Type;
+
+import javax.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public abstract class BaseMultiValuedAttributeEntityWithValue extends BaseMultiValuedAttributeEntity {
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     private String value;
 
     public String getValue() {

--- a/src/main/java/org/osiam/storage/entities/ExtensionEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionEntity.java
@@ -26,7 +26,15 @@ package org.osiam.storage.entities;
 import org.hibernate.annotations.Type;
 import org.osiam.resources.exception.InvalidConstraintException;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,8 +55,7 @@ public class ExtensionEntity {
     @GeneratedValue(generator = "sequence_scim_extension")
     private long internalId;
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     @Column(nullable = false)
     private String urn;
 

--- a/src/main/java/org/osiam/storage/entities/ExtensionFieldEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionFieldEntity.java
@@ -23,20 +23,20 @@
  */
 package org.osiam.storage.entities;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import org.osiam.resources.scim.ExtensionFieldType;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Index;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-
-import org.osiam.resources.scim.ExtensionFieldType;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Defines a field in a scim-extension.
@@ -98,6 +98,7 @@ public class ExtensionFieldEntity {
     private boolean required;
 
     @ManyToOne
+    @JoinColumn(name = "extension", nullable = false)
     private ExtensionEntity extension;
 
     public ExtensionEntity getExtension() {

--- a/src/main/java/org/osiam/storage/entities/ExtensionFieldValueEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ExtensionFieldValueEntity.java
@@ -23,18 +23,17 @@
  */
 package org.osiam.storage.entities;
 
+import org.hibernate.annotations.Type;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-
-import org.hibernate.annotations.Type;
 
 /**
  * Defines a value of a field of a scim-extension. It's user-dependent!
@@ -58,10 +57,10 @@ public class ExtensionFieldValueEntity {
     private long internalId;
 
     @ManyToOne(optional = false)
+    @JoinColumn(name = "extension_field", nullable = false)
     private ExtensionFieldEntity extensionField;
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     @Column(nullable = false)
     private String value;
 

--- a/src/main/java/org/osiam/storage/entities/GroupEntity.java
+++ b/src/main/java/org/osiam/storage/entities/GroupEntity.java
@@ -23,18 +23,18 @@
  */
 package org.osiam.storage.entities;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToMany;
-import javax.persistence.Table;
-
+import com.google.common.collect.ImmutableSet;
 import org.hibernate.annotations.BatchSize;
 import org.osiam.resources.scim.MemberRef.Type;
 
-import com.google.common.collect.ImmutableSet;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Entity class for {@link org.osiam.resources.scim.Group} resources
@@ -46,6 +46,10 @@ public class GroupEntity extends ResourceEntity {
     private static final int BATCH_SIZE = 100;
 
     @ManyToMany
+    @JoinTable(
+            joinColumns = @JoinColumn(name = "groups", nullable = false),
+            inverseJoinColumns = @JoinColumn(name = "members", nullable = false)
+    )
     @BatchSize(size = BATCH_SIZE)
     private Set<ResourceEntity> members = new HashSet<>();
 

--- a/src/main/java/org/osiam/storage/entities/MetaEntity.java
+++ b/src/main/java/org/osiam/storage/entities/MetaEntity.java
@@ -23,18 +23,16 @@
  */
 package org.osiam.storage.entities;
 
-import java.util.Calendar;
-import java.util.Date;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Index;
-import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-
-import org.hibernate.annotations.Type;
+import java.util.Calendar;
+import java.util.Date;
 
 @Entity
 @Table(name = "scim_meta",
@@ -59,8 +57,7 @@ public class MetaEntity {
 
     private Date lastModified;
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     private String location;
 
     private String version;

--- a/src/main/java/org/osiam/storage/entities/NameEntity.java
+++ b/src/main/java/org/osiam/storage/entities/NameEntity.java
@@ -23,14 +23,13 @@
  */
 package org.osiam.storage.entities;
 
+import org.hibernate.annotations.Type;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.Lob;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-
-import org.hibernate.annotations.Type;
 
 /**
  * Name Entity
@@ -50,8 +49,7 @@ public class NameEntity {
     @GeneratedValue(generator = "sequence_scim_name")
     private long id;
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     private String formatted;
 
     private String familyName;

--- a/src/main/java/org/osiam/storage/entities/ResourceEntity.java
+++ b/src/main/java/org/osiam/storage/entities/ResourceEntity.java
@@ -23,10 +23,8 @@
  */
 package org.osiam.storage.entities;
 
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import com.google.common.collect.ImmutableSet;
+import org.osiam.resources.scim.MemberRef.Type;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -35,14 +33,16 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import org.osiam.resources.scim.MemberRef.Type;
-
-import com.google.common.collect.ImmutableSet;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 @Entity
 @Table(name = "scim_id")
@@ -67,6 +67,7 @@ public abstract class ResourceEntity {
     private String externalId;
 
     @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "meta")
     private MetaEntity meta = new MetaEntity(GregorianCalendar.getInstance());
 
     @ManyToMany(mappedBy = "members")

--- a/src/main/java/org/osiam/storage/entities/UserEntity.java
+++ b/src/main/java/org/osiam/storage/entities/UserEntity.java
@@ -28,7 +28,13 @@ import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
 import org.osiam.resources.scim.MemberRef;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -46,12 +52,12 @@ public class UserEntity extends ResourceEntity {
     private String userName;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "name")
     private NameEntity name;
 
     private String nickName;
 
-    @Lob
-    @Type(type = "org.hibernate.type.StringClobType")
+    @Type(type = "text")
     private String profileUrl;
 
     private String title;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,6 @@ logging.level:
 
 spring.main.banner-mode: 'off'
 spring.thymeleaf.prefix: file:${osiam.home}/templates/web/
-spring.jpa.hibernate.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy
 spring.jpa.hibernate.ddl-auto: none
 server.port: ${osiam.port:8080}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,7 @@ spring.thymeleaf.prefix: file:${osiam.home}/templates/web/
 spring.jpa.hibernate.naming_strategy: org.hibernate.cfg.ImprovedNamingStrategy
 spring.jpa.hibernate.ddl-auto: none
 server.port: ${osiam.port:8080}
+
+flyway:
+  locations: db/migration/${osiam.db.vendor}
+  baseline-on-migrate: true

--- a/src/test/groovy/org/osiam/scim/extension/ExtensionsConfigurationSpec.groovy
+++ b/src/test/groovy/org/osiam/scim/extension/ExtensionsConfigurationSpec.groovy
@@ -23,15 +23,8 @@
  */
 package org.osiam.scim.extension
 
-import org.osiam.Osiam
 import org.osiam.resources.scim.ExtensionFieldType
 import org.osiam.storage.ExtensionRepository
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.EnvironmentTestUtils
-import org.springframework.boot.test.SpringApplicationConfiguration
-import org.springframework.context.ApplicationContextInitializer
-import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.core.env.ConfigurableEnvironment
 import spock.lang.Specification
 
 class ExtensionsConfigurationSpec extends Specification {


### PR DESCRIPTION
Remove `@Lob` and change `@Type` to `text` for text fields with variable
length. Hibernate 5 removed the type `StringClobType` and `text` is the
best replacement, as it does not map Strings to CLOBs, which does not work
with PotgreSQL.

Explicitly name some columns, as the naming strategy changed again in
Hibernate 5 and changing the column names in the database schema is rather
hard to do. This commit's scope is to only update Spring Boot.

Remove or replace deprecated things like
`spring.jpa.hibernate.naming_strategy` configuration property or
`org.springframework.boot.context.web.SpringBootServletInitializer`.

Also, do some code cleanup, use Spring Boot's auto configuration for
Flyway, and include Spring Boot devtools support. See individual commits
for details.

Resolves #258
