### PR TITLE
Fix typo in the initially created OAuth 2 client's client ID

### DIFF
--- a/docs/detailed-reference-installation.md
+++ b/docs/detailed-reference-installation.md
@@ -320,7 +320,7 @@ OSIAM also creates an initial OAuth 2 client:
 
 <dl>
     <dt>Client ID</dt>
-    <dd>example client</dd>
+    <dd>example-client</dd>
     <dt>Client secret</dt>
     <dd>secret</dd>
     <dt>Client redirect URI</dt>


### PR DESCRIPTION
The client ID actually has a hyphen between the words example and client.
