### PR TITLE
Revert "Update to Spring Boot version 1.4.2"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.1.RELEASE")
+    }
+}
+
 plugins {
     id 'antlr'
     id 'java'
@@ -9,8 +18,9 @@ plugins {
     id 'com.github.hierynomus.license' version '0.13.1'
     id 'com.github.kt3k.coveralls' version '2.6.3'
     id 'com.jfrog.bintray' version '1.7.2'
-    id 'org.springframework.boot' version '1.4.2.RELEASE'
 }
+
+apply plugin: 'spring-boot'
 
 group = 'org.osiam'
 


### PR DESCRIPTION
This reverts commit 62964efb4b68f398a3237c7cb19048e546484755.

Version 1.4.2 seems to introduce some serious classpath issues. This must be further investigated, but for now let's just roll back to 1.4.1 and hope that 1.4.3 will fix the issues.