### PR TITLE
Increase the length of client id to 255 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 - Remove `/Metrics` endpoint
+- Increase length of client ids to 255 characters
 
 ## 3.0 - 2016-08-09
 

--- a/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
+++ b/src/main/java/org/osiam/auth/oauth_client/ClientEntity.java
@@ -53,7 +53,7 @@ import java.util.UUID;
 @Table(name = "osiam_client")
 public class ClientEntity implements ClientDetails {
 
-    private static final int ID_LENGTH = 32;
+    private static final int ID_LENGTH = 255;
     private static final int SEQUENCE_INITIAL_VALUE = 100;
     private static final int SEQUENCE_ALLOCATION_SIZE = 1;
 

--- a/src/main/resources/db/migration/h2/V3__increase_client_id_length.sql
+++ b/src/main/resources/db/migration/h2/V3__increase_client_id_length.sql
@@ -1,0 +1,24 @@
+--
+-- The MIT License (MIT)
+--
+-- Copyright (C) 2013-2016 tarent solutions GmbH
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+ALTER TABLE PUBLIC.OSIAM_CLIENT ALTER COLUMN ID VARCHAR(255) NOT NULL;

--- a/src/main/resources/db/migration/mysql/V3__increase_client_id_length.sql
+++ b/src/main/resources/db/migration/mysql/V3__increase_client_id_length.sql
@@ -1,0 +1,24 @@
+--
+-- The MIT License (MIT)
+--
+-- Copyright (C) 2013-2016 tarent solutions GmbH
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+ALTER TABLE osiam_client MODIFY id VARCHAR(255) NOT NULL;

--- a/src/main/resources/db/migration/postgresql/V3__increase_client_id.sql
+++ b/src/main/resources/db/migration/postgresql/V3__increase_client_id.sql
@@ -1,0 +1,24 @@
+--
+-- The MIT License (MIT)
+--
+-- Copyright (C) 2013-2016 tarent solutions GmbH
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+ALTER TABLE osiam_client ALTER COLUMN id TYPE VARCHAR(255);


### PR DESCRIPTION
The length of the scim client id was limited to 32 characters. That was
a little short to be useful. This commit inreases the length to more
useful 255 characters.

Resolves #263 closes #264